### PR TITLE
external-secrets を ArgoCD App にて Helm を用いてデプロイするようにした

### DIFF
--- a/argocd-infra/argocd-apps.yaml
+++ b/argocd-infra/argocd-apps.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+  namespace: argocd
+spec:
+  destination:
+    namespace: external-secrets
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    chart: kubernetes-external-secrets
+    repoURL: https://external-secrets.github.io/kubernetes-external-secrets/
+    targetRevision: 6.1.0
+    helm:
+      parameters:
+      - name: env.AWS_REGION
+        value: ap-northeast-1
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true


### PR DESCRIPTION
タイトル通り

ディレクトリ構成は後段の PR で以下のように整える予定 (他案があればください！)

```
.
├── cfn
│   └── <現状の /cnf 以下のファイル群>
└── manifests
    ├── app
    │   ├── argocd-apps
    │   │   └── <現状の /argocd-apps 以下のファイル群>
    │   ├── dreamkast
    │   │   └── <現状の /dreamkast 以下のファイル群>
    │   └── dreamkast-api-mock
    │       └── <現状の /dreamkast-api-mock 以下のファイル群>
    ├── argocd
    │   └── <現状の /argocd 以下のファイル群>
    └── infra
        ├── argocd-apps
        │   └── <現状の /argocd-infra 以下のファイル群>
        └── contour
            └── <現状の /contour 以下のファイル群>


```