### PR TITLE
update ArgoCD Apps' name

### DIFF
--- a/manifests/app/argocd-apps/development/dreamkast-dk-459.yaml
+++ b/manifests/app/argocd-apps/development/dreamkast-dk-459.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: dreamkast-dk-459
+  name: dreamkast-development-dk-459
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion

--- a/manifests/app/argocd-apps/development/dreamkast-dk-509.yaml
+++ b/manifests/app/argocd-apps/development/dreamkast-dk-509.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: dreamkast-dk-509
+  name: dreamkast-development-dk-509
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion

--- a/manifests/app/argocd-apps/development/dreamkast-staging.yaml
+++ b/manifests/app/argocd-apps/development/dreamkast-staging.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: dreamkast-staging
+  name: dreamkast-staging-main
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion

--- a/manifests/app/argocd-apps/development/dreamkast-ui-46.yaml
+++ b/manifests/app/argocd-apps/development/dreamkast-ui-46.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: dreamkast-ui-46
+  name: dreamkast-development-ui-46
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion

--- a/manifests/app/argocd-apps/development/dreamkast-ui-49.yaml
+++ b/manifests/app/argocd-apps/development/dreamkast-ui-49.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: dreamkast-ui-49
+  name: dreamkast-development-ui-49
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion

--- a/manifests/app/argocd-apps/development/dreamkast-ui-51.yaml
+++ b/manifests/app/argocd-apps/development/dreamkast-ui-51.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: dreamkast-ui-51
+  name: dreamkast-development-ui-51
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion

--- a/manifests/app/argocd-apps/development/dreamkast-ui-52.yaml
+++ b/manifests/app/argocd-apps/development/dreamkast-ui-52.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: dreamkast-ui-52
+  name: dreamkast-development-ui-52
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion

--- a/manifests/app/argocd-apps/production/dreamkast-main.yaml
+++ b/manifests/app/argocd-apps/production/dreamkast-main.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: dreamkast-main
+  name: dreamkast-production-main
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion

--- a/manifests/app/argocd-apps/template/dreamkast.yaml
+++ b/manifests/app/argocd-apps/template/dreamkast.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: dreamkast-BRANCH
+  name: dreamkast-ENVIRONMENT-BRANCH
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion


### PR DESCRIPTION
### 変更点

- (念の為) staging が dev / prd のどちらのクラスタに居ても良い用に ArgoCD Application の命名を変更

###  備考

- この PR は以下の PR の前提となっています
    - cloudnativedaysjp/dreamkast#511
    - cloudnativedaysjp/dreamkast-ui#53

- 当 PR の merge 時、一度すべての dreamkast が Argo CD により cascade delete されるため注意 (まだユーザに晒してないので横着してこのまま行かせてください:pray:)