### PR TITLE
[staging] Redis 移行: ElastiCache > K8s Deployment

### DIFF
--- a/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast.yaml
@@ -34,7 +34,7 @@ spec:
         - name: MYSQL_DATABASE
           value: "dreamkast"
         - name: REDIS_URL
-          value: "redis://drrlvc9l498pdp2.bp6loy.ng.0001.apne1.cache.amazonaws.com:6379"
+          value: "redis://dreamkast-redis:6379"
         - name: SENTRY_DSN
           value: "https://82e52bc9814f478a917a9f4b2a190202@o414348.ingest.sentry.io/5303654"
         - name: S3_BUCKET

--- a/manifests/app/dreamkast/overlays/staging/main/kustomization.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - secret.yaml
 - ingress.yaml
+- redis.yaml
 - ../../../base/
 patchesStrategicMerge:
 - deployment-dreamkast.yaml

--- a/manifests/app/dreamkast/overlays/staging/main/redis.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/redis.yaml
@@ -45,7 +45,7 @@ spec:
         resources:
           limits:
             cpu: "0.1"
-            memory: "100Mi"
+            memory: "200Mi"
         volumeMounts:
         - mountPath: /redis-master-data
           name: data
@@ -67,5 +67,5 @@ metadata:
   name: redis-config
 data:
   redis.conf: |
-    maxmemory 2mb
+    maxmemory 100mb
     maxmemory-policy allkeys-lru


### PR DESCRIPTION
以下より普段の CPU / Memory 使用量を確認してそれっぽい値を resources.limits と redis.conf に記述

https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#dashboards:name=ElasticCache;start=P14D