### PR TITLE
[production] Redis 移行: ElastiCache > K8s Deployment

### DIFF
--- a/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast.yaml
@@ -35,7 +35,7 @@ spec:
         - name: MYSQL_DATABASE
           value: "dreamkast"
         - name: REDIS_URL
-          value: "redis://drr6rmpqht3l361.bp6loy.ng.0001.apne1.cache.amazonaws.com:6379"
+          value: "redis://dreamkast-redis:6379"
         - name: SENTRY_DSN
           value: "https://443f0535beb64cd8b2e995d001e0903b@o414348.ingest.sentry.io/5350644"
         - name: S3_BUCKET

--- a/manifests/app/dreamkast/overlays/production/main/kustomization.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - secret.yaml
 - ingress.yaml
+- redis.yaml
 - ../../../base/
 patchesStrategicMerge:
 - deployment-dreamkast.yaml

--- a/manifests/app/dreamkast/overlays/production/main/redis.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/redis.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: redis:5.0.4
+        image: redis:6.0.5
         command:
           - redis-server
           - "/redis-master/redis.conf"

--- a/manifests/app/dreamkast/overlays/production/main/redis.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/redis.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dreamkast-redis
+  labels:
+    app: dreamkast
+spec:
+  ports:
+    - port: 6379
+  selector:
+    app: dreamkast
+    tier: redis
+  clusterIP: None
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dreamkast-redis
+  labels:
+    app: dreamkast
+spec:
+  selector:
+    matchLabels:
+      app: dreamkast
+      tier: redis
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: dreamkast
+        tier: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:5.0.4
+        command:
+          - redis-server
+          - "/redis-master/redis.conf"
+        env:
+        - name: MASTER
+          value: "true"
+        ports:
+        - containerPort: 6379
+        resources:
+          limits:
+            cpu: "1"
+            memory: "400Mi"
+        volumeMounts:
+        - mountPath: /redis-master-data
+          name: data
+        - mountPath: /redis-master
+          name: config
+      volumes:
+        - name: data
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: redis-config
+            items:
+            - key: redis.conf
+              path: redis.conf
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+data:
+  redis.conf: |
+    maxmemory 200mb
+    maxmemory-policy allkeys-lru

--- a/manifests/app/dreamkast/overlays/staging/main/redis.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/redis.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: redis:5.0.4
+        image: redis:6.0.5
         command:
           - redis-server
           - "/redis-master/redis.conf"

--- a/manifests/app/dreamkast/overlays/template/redis.yaml
+++ b/manifests/app/dreamkast/overlays/template/redis.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: redis:5.0.4
+        image: redis:6.0.5
         command:
           - redis-server
           - "/redis-master/redis.conf"


### PR DESCRIPTION
#50 の production 版
こちらも以下を参考にそれっぽい値を利用 (本当は負荷テストをやる必要があると思いますが、dreamkast はセッションストアでしか redis を利用していないことを確認したため、取り敢えずこれだけあれば十二分に足りると思っています)

* https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#dashboards:name=ElasticCache;start=2021-02-25T15:00:00Z;end=2021-02-26T14:59:59Z
    * pre event の日にち
* https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#dashboards:name=ElasticCache;start=P14D
    * ここ二週間