### PR TITLE
dreamkast-releasebot 用マニフェストの配置

### DIFF
--- a/manifests/app/argocd-apps/development/dreamkast-releasebot.yaml
+++ b/manifests/app/argocd-apps/development/dreamkast-releasebot.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dreamkast-releasebot
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion
+spec:
+  destination:
+    namespace: dreamkast-releasebot
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: manifests/app/dreamkast-releasebot/overlays/development
+    repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/manifests/app/dreamkast-releasebot/base/deployment.yaml
+++ b/manifests/app/dreamkast-releasebot/base/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dreamkast-releasebot
+  name: dreamkast-releasebot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dreamkast-releasebot
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: dreamkast-releasebot
+    spec:
+      containers:
+      - image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-releasebot:main
+        name: dreamkast-releasebot
+        args:
+          - --target-repositories=https://github.com/cloudnativedaysjp/dreamkast
+          - --target-repositories=https://github.com/cloudnativedaysjp/dreamkast-ui
+          - --base-branch=main
+          - --enable-auto-merge=false
+        env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: dreamkast-releasebot
+              key: GITHUB_TOKEN
+        - name: SLACK_BOT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: dreamkast-releasebot
+              key: SLACK_BOT_TOKEN
+        - name: SLACK_VERIFICATION_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: dreamkast-releasebot
+              key: SLACK_VERIFICATION_TOKEN
+        ports:
+        - containerPort: 8080
+        resources: {}

--- a/manifests/app/dreamkast-releasebot/base/ingress.yaml
+++ b/manifests/app/dreamkast-releasebot/base/ingress.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: dreamkast-releasebot-ingress
+  labels:
+    app: dreamkast-releasebot
+spec:
+  virtualhost:
+    fqdn: dreamkast-releasebot.dev.cloudnativedays.jp
+    tls:
+      secretName: cert-manager/wildcard-dev-cloudnativedays-jp
+  routes:
+    - conditions:
+      - prefix: /
+      services:
+      - name: dreamkast-releasebot
+        port: 8080

--- a/manifests/app/dreamkast-releasebot/base/kustomization.yaml
+++ b/manifests/app/dreamkast-releasebot/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- ingress.yaml
+- service.yaml
+- secret.yaml

--- a/manifests/app/dreamkast-releasebot/base/secret.yaml
+++ b/manifests/app/dreamkast-releasebot/base/secret.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: 'kubernetes-client.io/v1'
+kind: ExternalSecret
+metadata:
+  name: dreamkast-releasebot
+spec:
+  backendType: secretsManager
+  data:
+    - key: dreamkast-releasebot
+      name: GITHUB_TOKEN
+      property: GITHUB_TOKEN
+    - key: dreamkast-releasebot
+      name: SLACK_BOT_TOKEN
+      property: SLACK_BOT_TOKEN
+    - key: dreamkast-releasebot
+      name: SLACK_VERIFICATION_TOKEN
+      property: SLACK_VERIFICATION_TOKEN

--- a/manifests/app/dreamkast-releasebot/base/service.yaml
+++ b/manifests/app/dreamkast-releasebot/base/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: dreamkast-releasebot
+  name: dreamkast-releasebot
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: dreamkast-releasebot
+  type: NodePort

--- a/manifests/app/dreamkast-releasebot/overlays/development/kustomization.yaml
+++ b/manifests/app/dreamkast-releasebot/overlays/development/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dreamkast-releasebot
+resources:
+- ../../base
+images:
+- name: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-releasebot
+  newTag: latest


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast-releasebot を dev で動作させるための PR

### TODO

- [x] [SecretManager](https://ap-northeast-1.console.aws.amazon.com/secretsmanager/home?region=ap-northeast-1#!/secret?name=dreamkast-releasebot) に適切な value を与える
    - GITHUB_TOKEN
    - SLACK_BOT_TOKEN
    - SLACK_VERIFICATION_TOKEN
- [x] dreamkast-releasebot 用イメージを ECR に push する