### PR TITLE
update dreamkast's base manifests

### DIFF
--- a/manifests/app/dreamkast/base/deployment.yaml
+++ b/manifests/app/dreamkast/base/deployment.yaml
@@ -3,11 +3,13 @@ kind: Deployment
 metadata:
   labels:
     app: dreamkast
+    tier: dreamkast
   name: dreamkast
 spec:
   selector:
     matchLabels:
       app: dreamkast
+      tier: dreamkast
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -38,6 +40,7 @@ kind: Deployment
 metadata:
   labels:
     app: dreamkast
+    tier: dreamkast-ui
   name: dreamkast-ui
 spec:
   replicas: 1
@@ -58,7 +61,6 @@ spec:
         name: dreamkast-ui
         ports:
         - containerPort: 3001
-        resources: {}
         livenessProbe:
           httpGet:
             port: 3001
@@ -77,3 +79,10 @@ spec:
             path: /cndo2021/ui/
           failureThreshold: 30
           periodSeconds: 10
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"

--- a/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: dreamkast
+    tier: dreamkast
   name: dreamkast
 spec:
   replicas: 1
@@ -10,6 +11,7 @@ spec:
   selector:
     matchLabels:
       app: dreamkast
+      tier: dreamkast
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -96,6 +98,7 @@ kind: Deployment
 metadata:
   labels:
     app: dreamkast
+    tier: dreamkast-ui
   name: dreamkast-ui
 spec:
   replicas: 3
@@ -115,4 +118,3 @@ spec:
         name: dreamkast-ui
         ports:
         - containerPort: 3001
-        resources: {}

--- a/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast.yaml
@@ -3,12 +3,14 @@ kind: Deployment
 metadata:
   labels:
     app: dreamkast
+    tier: dreamkast
   name: dreamkast
 spec:
   revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: dreamkast
+      tier: dreamkast
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -25,7 +27,6 @@ spec:
         image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ecs:main
         ports:
           - containerPort: 3000
-            resources:
         env:
         - name: RAILS_ENV
           value: "production"
@@ -95,6 +96,7 @@ kind: Deployment
 metadata:
   labels:
     app: dreamkast
+    tier: dreamkast-ui
   name: dreamkast-ui
 spec:
   replicas: 1
@@ -114,4 +116,3 @@ spec:
         name: dreamkast-ui
         ports:
         - containerPort: 3001
-        resources: {}

--- a/manifests/app/dreamkast/overlays/template/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/template/deployment-dreamkast.yaml
@@ -3,11 +3,13 @@ kind: Deployment
 metadata:
   labels:
     app: dreamkast
+    tier: dreamkast
   name: dreamkast
 spec:
   selector:
     matchLabels:
       app: dreamkast
+      tier: dreamkast
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -17,6 +19,7 @@ spec:
     metadata:
       labels:
         app: dreamkast
+        tier: dreamkast
     spec:
       containers:
       - name: dreamkast
@@ -28,7 +31,6 @@ spec:
               command: ["/bin/sh", "-c", "bin/rails db:migrate && bin/rails db:seed"]
         ports:
           - containerPort: 3000
-            resources:
         env:
         - name: RAILS_ENV
           value: "production"


### PR DESCRIPTION
merge 後 Argo CD にて sync error が発生するので以下の対応をする

* エラーの理由: dreamkast Deployment の matchLabel が immutable Field であるため
* 対応: dreamkast Deployment を kubectl から削除し、その後すぐ Argo CD WebUI よりデプロイを実施する