### PR TITLE
dev cluster廃止に伴いマニフェストの当て先をprd clusterに変更

### DIFF
--- a/manifests/argocd/overlays/production/argocd-apps/dreamkast.yaml
+++ b/manifests/argocd/overlays/production/argocd-apps/dreamkast.yaml
@@ -18,3 +18,23 @@ spec:
       prune: true
     syncOptions:
     - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dreamkast-apps-dev
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: manifests/app/argocd-apps/development
+    repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/manifests/argocd/overlays/production/argocd-apps/metrics-server.yaml
+++ b/manifests/argocd/overlays/production/argocd-apps/metrics-server.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metrics-server
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: manifests/release
+    repoURL: https://github.com/kubernetes-sigs/metrics-server.git
+    targetRevision: v0.4.2
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true


### PR DESCRIPTION
dev manifest の廃止は別 PR にて実施