### PR TITLE
backend protocolを削除してIPモードのNLBを使う

### DIFF
--- a/manifests/infra/contour/base/contour.yaml
+++ b/manifests/infra/contour/base/contour.yaml
@@ -1624,14 +1624,6 @@ metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
   namespace: projectcontour
-  annotations:
-    # This annotation puts the AWS ELB into "TCP" mode so that it does not
-    # do HTTP negotiation for HTTPS connections at the ELB edge.
-    # The downside of this is the remote IP address of all connections will
-    # appear to be the internal address of the ELB. See docs/proxy-proto.md
-    # for information about enabling the PROXY protocol on the ELB to recover
-    # the original remote IP address.
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
 spec:
   externalTrafficPolicy: Local
   ports:


### PR DESCRIPTION
アノテーションが別れてて上書きされていることに気づいた