### PR TITLE
メール配信用に SQS のリソースを追加

### DIFF
--- a/cfn/sqs.yaml
+++ b/cfn/sqs.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description:
+  SQS queue Create
+
+Type: AWS::SQS::Queue
+Properties:
+  ContentBasedDeduplication: True
+  DelaySeconds: 10
+  FifoQueue: True
+  MessageRetentionPeriod: 60
+  QueueName: MailQueue
+  RedrivePolicy: Json

--- a/cfn/sqs.yaml
+++ b/cfn/sqs.yaml
@@ -2,11 +2,23 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description:
   SQS queue Create
 
-Type: AWS::SQS::Queue
-Properties:
-  ContentBasedDeduplication: True
-  DelaySeconds: 10
-  FifoQueue: True
-  MessageRetentionPeriod: 60
-  QueueName: MailQueue
-  RedrivePolicy: Json
+# ------------------------------------------------------------#
+# Input Parameters
+# ------------------------------------------------------------#
+Parameters:
+  PJPrefix:
+    Type: String
+
+Resources:
+# ------------------------------------------------------------#
+#  SQS
+# ------------------------------------------------------------#
+# SQS Create
+  SQS:
+    Type: AWS::SQS::Queue
+    Properties:
+      ContentBasedDeduplication: True
+      DelaySeconds: 10
+      FifoQueue: True
+      MessageRetentionPeriod: 60
+      QueueName: !Sub "${PJPrefix}MailQueue.fifo"

--- a/manifests/app/dreamkast/base/deployment.yaml
+++ b/manifests/app/dreamkast/base/deployment.yaml
@@ -44,6 +44,51 @@ kind: Deployment
 metadata:
   labels:
     app: dreamkast
+    tier: dreamkast
+  name: dreamkast
+spec:
+  selector:
+    matchLabels:
+      app: dreamkast
+      tier: dreamkast-mail-worker
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: dreamkast
+        tier: dreamkast-mail-worker
+    spec:
+      containers:
+      - name: dreamkast
+        image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ecs:main
+        command: ["bundle"]
+        args: [
+          "exec",
+          "aws_sqs_active_job",
+          "--queue",
+          "mail"
+        ]
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "400m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sleep","300"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dreamkast
     tier: dreamkast-ui
   name: dreamkast-ui
 spec:

--- a/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast.yaml
@@ -45,6 +45,8 @@ spec:
           value: "dreamkast-prd-bucket"
         - name: S3_REGION
           value: ap-northeast-1
+        - name: SQS_MAIL_QUEUE_URL
+          value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/prodMailQueue.fifo"
         - name: RAILS_MASTER_KEY
           valueFrom:
             secretKeyRef:

--- a/manifests/app/dreamkast/overlays/template/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/template/deployment-dreamkast.yaml
@@ -43,7 +43,7 @@ spec:
         - name: S3_REGION
           value: ap-northeast-1
         - name: SQS_MAIL_QUEUE_URL
-          value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/MailQueue.fifo"
+          value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/devMailQueue.fifo"
         - name: RAILS_MASTER_KEY
           valueFrom:
             secretKeyRef:

--- a/manifests/app/dreamkast/overlays/template/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/template/deployment-dreamkast.yaml
@@ -42,6 +42,8 @@ spec:
           value: "dreamkast-test-bucket"
         - name: S3_REGION
           value: ap-northeast-1
+        - name: SQS_MAIL_QUEUE_URL
+          value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/MailQueue.fifo"
         - name: RAILS_MASTER_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## 概要

メール送信用にSQSに `MailQueue` を作成  
パラメータは FIFO queue であること以外は基本 default を使用しています

ActiveJob の Worker 用にプロセスを作る必要があるのですが、これをどのノードにまかせるべきかが未定なので検討後パラメータに追加する必要があります(Draft でとどめています)