### PR TITLE
add loki, promtail via loki-stack

### DIFF
--- a/manifests/argocd/overlays/development/argocd-apps/loki.yaml
+++ b/manifests/argocd/overlays/development/argocd-apps/loki.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: loki
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion
+spec:
+  destination:
+    namespace: monitoring
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    chart: loki-stack
+    repoURL: https://grafana.github.io/helm-charts
+    targetRevision: 2.4.1
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/manifests/argocd/overlays/development/argocd-apps/loki.yaml
+++ b/manifests/argocd/overlays/development/argocd-apps/loki.yaml
@@ -15,6 +15,10 @@ spec:
     chart: loki-stack
     repoURL: https://grafana.github.io/helm-charts
     targetRevision: 2.4.1
+    helm:
+      parameters:
+      - name: loki.persistence.enabled
+        value: "true"
   syncPolicy:
     automated:
       prune: true

--- a/manifests/argocd/overlays/production/argocd-apps/loki.yaml
+++ b/manifests/argocd/overlays/production/argocd-apps/loki.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: loki
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion
+spec:
+  destination:
+    namespace: monitoring
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    chart: loki-stack
+    repoURL: https://grafana.github.io/helm-charts
+    targetRevision: 2.4.1
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/manifests/argocd/overlays/production/argocd-apps/loki.yaml
+++ b/manifests/argocd/overlays/production/argocd-apps/loki.yaml
@@ -15,6 +15,10 @@ spec:
     chart: loki-stack
     repoURL: https://grafana.github.io/helm-charts
     targetRevision: 2.4.1
+    helm:
+      parameters:
+      - name: loki.persistence.enabled
+        value: "true"
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
### 動作確認

```
$ k -n monitoring get all -l release=loki
NAME                      READY   STATUS    RESTARTS   AGE
pod/loki-0                1/1     Running   0          19m
pod/loki-promtail-ggmxq   1/1     Running   0          19m
pod/loki-promtail-xlfdd   1/1     Running   0          19m
pod/loki-promtail-z2ht2   1/1     Running   0          19m

NAME                    TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
service/loki            ClusterIP   10.96.220.71   <none>        3100/TCP   19m
service/loki-headless   ClusterIP   None           <none>        3100/TCP   19m

NAME                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/loki-promtail   3         3         3       3            3           <none>          19m

NAME                    READY   AGE
statefulset.apps/loki   1/1     19m

$ k -n monitoring port-forward svc/loki 3100:3100
$ export LOKI_ADDR=http://localhost:3100

$ logcli labels job
http://localhost:3100/loki/api/v1/label/job/values?end=1628032381338231000&start=1628028781338231000
argocd/argocd-application-controller
argocd/argocd-dex-server
argocd/argocd-redis
argocd/argocd-repo-server
argocd/argocd-server
cert-manager/cainjector
cert-manager/cert-manager
cert-manager/webhook
dreamkast-dk-716/dreamkast
dreamkast-dk-727/dreamkast
dreamkast-staging/dreamkast
external-secrets/external-secrets-kubernetes-external-secrets
kube-system/coredns
kube-system/etcd
kube-system/kindnet
kube-system/kube-apiserver
kube-system/kube-controller-manager
kube-system/kube-proxy
kube-system/kube-scheduler
kube-system/metrics-server
local-path-storage/local-path-provisioner
monitoring/loki
monitoring/node-exporter
monitoring/prometheus
monitoring/prometheus-operator
monitoring/promtail
projectcontour/contour
projectcontour/contour-certgen
projectcontour/envoy

$ logcli query '{job="monitoring/node-exporter"}'
http://localhost:3100/loki/api/v1/query_range?direction=BACKWARD&end=1628032446187143000&limit=30&query=%7Bjob%3D%22monitoring%2Fnode-exporter%22%7D&start=1628028846187143000
Common labels: {app_kubernetes_io_component="exporter", app_kubernetes_io_name="node-exporter", app_kubernetes_io_part_of="kube-prometheus", app_kubernetes_io_version="1.1.2", controller_revision_hash="b48d9d86d", job="monitoring/node-exporter", namespace="monitoring", pod_template_generation="1"}
2021-08-04T08:09:48+09:00 {container="kube-rbac-proxy", filename="/var/log/pods/monitoring_node-exporter-24n9t_5608b38f-fe8e-4a3f-809e-6351edef4a9e/kube-rbac-proxy/0.log", pod="node-exporter-24n9t"} 2021-08-03T23:09:48.221895627Z stderr F 2021/08/03 23:09:48 http: proxy error: context canceled
2021-08-04T08:01:21+09:00 {container="kube-rbac-proxy", filename="/var/log/pods/monitoring_node-exporter-24n9t_5608b38f-fe8e-4a3f-809e-6351edef4a9e/kube-rbac-proxy/0.log", pod="node-exporter-24n9t"} 2021-08-03T23:01:21.012283097Z stderr F 2021/08/03 23:01:21 http: proxy error: context canceled
2021-08-04T07:58:57+09:00 {container="kube-rbac-proxy", filename="/var/log/pods/monitoring_node-exporter-24n9t_5608b38f-fe8e-4a3f-809e-6351edef4a9e/kube-rbac-proxy/0.log", pod="node-exporter-24n9t"} 2021-08-03T22:58:57.474287461Z stderr F E0803 22:58:57.473397    4477 proxy.go:96] Authorization error (user=system:serviceaccount:monitoring:prometheus-k8s, verb=get, resource=, subresource=): context canceled
2021-08-04T07:58:57+09:00 {container="kube-rbac-proxy", filename="/var/log/pods/monitoring_node-exporter-24n9t_5608b38f-fe8e-4a3f-809e-6351edef4a9e/kube-rbac-proxy/0.log", pod="node-exporter-24n9t"} 2021-08-03T22:58:57.373486419Z stderr F E0803 22:58:57.273071    4477 webhook.go:199] Failed to make webhook authorizer request: context canceled
2021-08-04T07:58:45+09:00 {container="kube-rbac-proxy", filename="/var/log/pods/monitoring_node-exporter-24n9t_5608b38f-fe8e-4a3f-809e-6351edef4a9e/kube-rbac-proxy/0.log", pod="node-exporter-24n9t"} 2021-08-03T22:58:45.972901053Z stderr F I0803 22:58:45.971900    4477 main.go:318] Listening securely on [172.18.0.3]:9100

$ logcli series -q '{namespace="projectcontour",container="contour"}'
{app="contour", container="contour", filename="/var/log/pods/projectcontour_contour-767699876b-ldnpx_f0ad591c-2935-43c1-81c4-6dd832f26a28/contour/0.log", job="projectcontour/contour", namespace="projectcontour", pod="contour-767699876b-ldnpx", pod_template_hash="767699876b"}
{app="contour", container="contour", filename="/var/log/pods/projectcontour_contour-767699876b-x47nl_c78e326d-cf35-4719-864a-a2fcd2e719f5/contour/0.log", job="projectcontour/contour", namespace="projectcontour", pod="contour-767699876b-x47nl", pod_template_hash="767699876b"}
{app="contour", container="contour", filename="/var/log/pods/projectcontour_contour-767699876b-x47nl_c78e326d-cf35-4719-864a-a2fcd2e719f5/contour/1.log", job="projectcontour/contour", namespace="projectcontour", pod="contour-767699876b-x47nl", pod_template_hash="767699876b"}
{app="contour", container="contour", filename="/var/log/pods/projectcontour_contour-767699876b-x47nl_c78e326d-cf35-4719-864a-a2fcd2e719f5/contour/2.log", job="projectcontour/contour", namespace="projectcontour", pod="contour-767699876b-x47nl", pod_template_hash="767699876b"}
{app="contour-certgen", container="contour", controller_uid="6175a2d5-cc6d-4b24-a825-543942bbdc06", filename="/var/log/pods/projectcontour_contour-certgen-v1.11.0-wbw4g_585570f8-56a7-4b66-a2af-c0a257685630/contour/0.log", job="projectcontour/contour-certgen", job_name="contour-certgen-v1.11.0", namespace="projectcontour", pod="contour-certgen-v1.11.0-wbw4g"}
```

### やらなかったこと

- grafanaを入れる（kntksさん検証中）
- ~~PVC/PVを使う~~