### PR TITLE
add cronjob to notify registration situation to slack

### DIFF
--- a/manifests/app/dreamkast/overlays/production/main/cronjob.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/cronjob.yaml
@@ -1,0 +1,70 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: post-to-cicd2021-registration-status
+spec:
+  schedule: "0 */10 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: dreamkast
+              image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ecs:9ba0239079648f59f91d2c6fa3bb864cdc34020c
+              command:
+                - /bin/sh
+                - -c
+                - bundle exec rake util:post_number_of_registrants_to_slack
+              env:
+                - name: SLACK_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: SLACK_WEBHOOK_URL
+                - name: CONFERENCE_ABBR
+                  value: "cicd2021"
+                - name: RAILS_ENV
+                  value: "production"
+                - name: MYSQL_HOST
+                  value: "dreamkast-prd-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+                - name: MYSQL_DATABASE
+                  value: "dreamkast"
+                - name: REDIS_URL
+                  value: "redis://dreamkast-redis:6379"
+                - name: SENTRY_DSN
+                  value: "https://443f0535beb64cd8b2e995d001e0903b@o414348.ingest.sentry.io/5350644"
+                - name: S3_BUCKET
+                  value: "dreamkast-prd-bucket"
+                - name: S3_REGION
+                  value: ap-northeast-1
+                - name: RAILS_MASTER_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: rails-app-secret
+                      key: rails-app-secret
+                - name: MYSQL_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: db-secret
+                      key: username
+                - name: MYSQL_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: db-secret
+                      key: password
+                - name: AUTH0_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: AUTH0_CLIENT_ID
+                - name: AUTH0_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: AUTH0_CLIENT_SECRET
+                - name: AUTH0_DOMAIN
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: AUTH0_DOMAIN
+          restartPolicy: OnFailure

--- a/manifests/app/dreamkast/overlays/production/main/cronjob.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/cronjob.yaml
@@ -3,7 +3,8 @@ kind: CronJob
 metadata:
   name: post-to-cicd2021-registration-status
 spec:
-  schedule: "0 */10 * * *"
+  # Execute every 10:00 JST but this configure is written by UTC
+  schedule: "0 */1 * * *"
   jobTemplate:
     spec:
       template:

--- a/manifests/app/dreamkast/overlays/production/main/cronjob.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/cronjob.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: dreamkast
-              image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ecs:9ba0239079648f59f91d2c6fa3bb864cdc34020c
+              image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ecs:main
               command:
                 - /bin/sh
                 - -c

--- a/manifests/app/dreamkast/overlays/production/main/kustomization.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - ingress.yaml
 - redis.yaml
 - hpa.yaml
+- cronjob.yaml
 - ../../../base/
 patchesStrategicMerge:
 - deployment-dreamkast.yaml

--- a/manifests/app/dreamkast/overlays/production/main/secret.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/secret.yaml
@@ -29,4 +29,7 @@ spec:
     - key: dreamkast/production-env
       name: AUTH0_DOMAIN
       property: AUTH0_DOMAIN
+    - key: dreamkast/production-env
+      name: SLACK_WEBHOOK_URL
+      property: SLACK_WEBHOOK_URL
 


### PR DESCRIPTION
- 毎朝10時にcndt2021チャンネルにCICD2021の登録者人数を通知します。

fix https://github.com/cloudnativedaysjp/dreamkast/issues/710