### PR TITLE
Change route for UI

### DIFF
--- a/manifests/app/dreamkast/base/deployment.yaml
+++ b/manifests/app/dreamkast/base/deployment.yaml
@@ -116,19 +116,19 @@ spec:
         livenessProbe:
           httpGet:
             port: 3001
-            path: /cndo2021/ui/
+            path: /cicd2021/ui/
           failureThreshold: 5
           periodSeconds: 5
         readinessProbe:
           httpGet:
             port: 3001
-            path: /cndo2021/ui/
+            path: /cicd2021/ui/
           failureThreshold: 5
           periodSeconds: 5
         startupProbe:
           httpGet:
             port: 3001
-            path: /cndo2021/ui/
+            path: /cicd2021/ui/
           failureThreshold: 30
           periodSeconds: 10
         resources:

--- a/manifests/app/dreamkast/overlays/production/main/ingress.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/ingress.yaml
@@ -23,7 +23,7 @@ spec:
       - name: dreamkast
         port: 80
     - conditions:
-      - prefix: /cndo2021/ui
+      - prefix: /cicd2021/ui
       services:
       - name: dreamkast-ui
         port: 3001

--- a/manifests/app/dreamkast/overlays/staging/main/ingress.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/ingress.yaml
@@ -23,7 +23,7 @@ spec:
       - name: dreamkast
         port: 80
     - conditions:
-      - prefix: /cndo2021/ui
+      - prefix: /cicd2021/ui
       services:
       - name: dreamkast-ui
         port: 3001

--- a/manifests/app/dreamkast/overlays/template/ingress.yaml
+++ b/manifests/app/dreamkast/overlays/template/ingress.yaml
@@ -22,8 +22,8 @@ spec:
       services:
       - name: dreamkast
         port: 80
-    - conditions:
-      - prefix: /cndo2021/ui
+    - conditions: #TODO: Need to resolve this hardcoded routing
+      - prefix: /cicd2021/ui
       services:
       - name: dreamkast-ui
         port: 3001


### PR DESCRIPTION
CICDでUIを有効にするための修正。
本当はワイルドカードを使ってどのパスであっても対応できるようにしたかったけど、Contourはそれが出来ない様子・・・
https://github.com/projectcontour/contour/issues/1179

CNDOのパスはもう使うことがないので削除。今のままだとCNDT2021でも同様の対処は必要になるが、
https://github.com/cloudnativedaysjp/dreamkast/issues/674
が実現できればそもそもこのroutesは不要になるため、今回はCICD向けのハードコードで対処することにした。くそダサいので今回限りにしたい･･･