### PR TITLE
add service-monitor for metrics-server

### DIFF
--- a/manifests/infra/prometheus/base/monitor.yaml
+++ b/manifests/infra/prometheus/base/monitor.yaml
@@ -118,3 +118,22 @@ spec:
   selector:
     matchLabels:
       app: envoy
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: metrics-server
+  namespace: monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      k8s-app: metrics-server


### PR DESCRIPTION
metrics-serverがexposeしているメトリクスをPrometheusで収集できました。
が、思っていたのと違うというか、PodごとのCPU/メモリ使用率などはありませんでした。
収集できたのでPR出しますが、不要であればクローズしてもらってよいです。

<details>
<summary>`https://metrics-server.kube-system/metrics`のレスポンス</summary>

```
# HELP apiserver_audit_event_total [ALPHA] Counter of audit events generated and sent to the audit backend.
# TYPE apiserver_audit_event_total counter
apiserver_audit_event_total 0
# HELP apiserver_audit_requests_rejected_total [ALPHA] Counter of apiserver requests rejected due to an error in audit logging backend.
# TYPE apiserver_audit_requests_rejected_total counter
apiserver_audit_requests_rejected_total 0
# HELP apiserver_client_certificate_expiration_seconds [ALPHA] Distribution of the remaining lifetime on the certificate used to authenticate a request.
# TYPE apiserver_client_certificate_expiration_seconds histogram
apiserver_client_certificate_expiration_seconds_bucket{le="0"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="1800"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="3600"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="7200"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="21600"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="43200"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="86400"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="172800"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="345600"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="604800"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="2.592e+06"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="7.776e+06"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="1.5552e+07"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="3.1104e+07"} 0
apiserver_client_certificate_expiration_seconds_bucket{le="+Inf"} 0
apiserver_client_certificate_expiration_seconds_sum 0
apiserver_client_certificate_expiration_seconds_count 0
# HELP apiserver_current_inflight_requests [ALPHA] Maximal number of currently used inflight request limit of this apiserver per request kind in last second.
# TYPE apiserver_current_inflight_requests gauge
apiserver_current_inflight_requests{request_kind="mutating"} 0
apiserver_current_inflight_requests{request_kind="readOnly"} 0
# HELP apiserver_envelope_encryption_dek_cache_fill_percent [ALPHA] Percent of the cache slots currently occupied by cached DEKs.
# TYPE apiserver_envelope_encryption_dek_cache_fill_percent gauge
apiserver_envelope_encryption_dek_cache_fill_percent 0
# HELP apiserver_request_duration_seconds [ALPHA] Response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component.
# TYPE apiserver_request_duration_seconds histogram
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.05"} 1636
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.1"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.15"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.2"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.25"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.3"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.35"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.4"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.45"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.5"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.6"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.7"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.8"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="0.9"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="1"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="1.25"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="1.5"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="1.75"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="2"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="2.5"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="3"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="3.5"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="4"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="4.5"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="5"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="6"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="7"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="8"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="9"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="10"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="15"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="20"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="25"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="30"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="40"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="50"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="60"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="+Inf"} 1637
apiserver_request_duration_seconds_sum{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version=""} 0.5228318649999997
apiserver_request_duration_seconds_count{component="",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version=""} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.05"} 1636
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.1"} 1637
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.15"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.2"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.25"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.3"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.35"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.4"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.45"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.5"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.6"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.7"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.8"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="0.9"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="1"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="1.25"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="1.5"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="1.75"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="2"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="2.5"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="3"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="3.5"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="4"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="4.5"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="5"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="6"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="7"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="8"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="9"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="10"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="15"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="20"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="25"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="30"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="40"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="50"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="60"} 1638
apiserver_request_duration_seconds_bucket{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="+Inf"} 1638
apiserver_request_duration_seconds_sum{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version=""} 1.5618435390000007
apiserver_request_duration_seconds_count{component="",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version=""} 1638
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.05"} 1062
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.1"} 1067
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.15"} 1067
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.2"} 1067
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.25"} 1067
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.3"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.35"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.4"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.45"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.5"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.6"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.7"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.8"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="0.9"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="1"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="1.25"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="1.5"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="1.75"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="2"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="2.5"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="3"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="3.5"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="4"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="4.5"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="5"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="6"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="7"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="8"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="9"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="10"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="15"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="20"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="25"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="30"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="40"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="50"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="60"} 1068
apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="+Inf"} 1068
apiserver_request_duration_seconds_sum{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1"} 3.6114714230000025
apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1"} 1068
# HELP apiserver_request_total [ALPHA] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response contentType and code.
# TYPE apiserver_request_total counter
apiserver_request_total{code="200",component="",contentType="text/plain;charset=utf-8",dry_run="",group="",resource="",scope="",subresource="/livez",verb="GET",version=""} 1637
apiserver_request_total{code="200",component="",contentType="text/plain;charset=utf-8",dry_run="",group="",resource="",scope="",subresource="/readyz",verb="GET",version=""} 1638
apiserver_request_total{code="200",component="apiserver",contentType="application/vnd.kubernetes.protobuf",dry_run="",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1"} 1068
# HELP apiserver_response_sizes [ALPHA] Response size distribution in bytes for each group, version, verb, resource, subresource, scope and component.
# TYPE apiserver_response_sizes histogram
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="1000"} 1637
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="10000"} 1637
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="100000"} 1637
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="1e+06"} 1637
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="1e+07"} 1637
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="1e+08"} 1637
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="1e+09"} 1637
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/livez",verb="GET",version="",le="+Inf"} 1637
apiserver_response_sizes_sum{component="",group="",resource="",scope="",subresource="/livez",verb="GET",version=""} 3274
apiserver_response_sizes_count{component="",group="",resource="",scope="",subresource="/livez",verb="GET",version=""} 1637
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="1000"} 1638
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="10000"} 1638
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="100000"} 1638
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="1e+06"} 1638
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="1e+07"} 1638
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="1e+08"} 1638
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="1e+09"} 1638
apiserver_response_sizes_bucket{component="",group="",resource="",scope="",subresource="/readyz",verb="GET",version="",le="+Inf"} 1638
apiserver_response_sizes_sum{component="",group="",resource="",scope="",subresource="/readyz",verb="GET",version=""} 3276
apiserver_response_sizes_count{component="",group="",resource="",scope="",subresource="/readyz",verb="GET",version=""} 1638
apiserver_response_sizes_bucket{component="apiserver",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="1000"} 1067
apiserver_response_sizes_bucket{component="apiserver",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="10000"} 1068
apiserver_response_sizes_bucket{component="apiserver",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="100000"} 1068
apiserver_response_sizes_bucket{component="apiserver",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="1e+06"} 1068
apiserver_response_sizes_bucket{component="apiserver",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="1e+07"} 1068
apiserver_response_sizes_bucket{component="apiserver",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="1e+08"} 1068
apiserver_response_sizes_bucket{component="apiserver",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="1e+09"} 1068
apiserver_response_sizes_bucket{component="apiserver",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1",le="+Inf"} 1068
apiserver_response_sizes_sum{component="apiserver",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1"} 132873
apiserver_response_sizes_count{component="apiserver",group="metrics.k8s.io",resource="pods",scope="namespace",subresource="",verb="LIST",version="v1beta1"} 1068
# HELP apiserver_storage_data_key_generation_duration_seconds [ALPHA] Latencies in seconds of data encryption key(DEK) generation operations.
# TYPE apiserver_storage_data_key_generation_duration_seconds histogram
apiserver_storage_data_key_generation_duration_seconds_bucket{le="5e-06"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="1e-05"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="2e-05"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="4e-05"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="8e-05"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.00016"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.00032"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.00064"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.00128"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.00256"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.00512"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.01024"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.02048"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.04096"} 0
apiserver_storage_data_key_generation_duration_seconds_bucket{le="+Inf"} 0
apiserver_storage_data_key_generation_duration_seconds_sum 0
apiserver_storage_data_key_generation_duration_seconds_count 0
# HELP apiserver_storage_data_key_generation_failures_total [ALPHA] Total number of failed data encryption key(DEK) generation operations.
# TYPE apiserver_storage_data_key_generation_failures_total counter
apiserver_storage_data_key_generation_failures_total 0
# HELP apiserver_storage_envelope_transformation_cache_misses_total [ALPHA] Total number of cache misses while accessing key decryption key(KEK).
# TYPE apiserver_storage_envelope_transformation_cache_misses_total counter
apiserver_storage_envelope_transformation_cache_misses_total 0
# HELP apiserver_tls_handshake_errors_total [ALPHA] Number of requests dropped with 'TLS handshake error from' error
# TYPE apiserver_tls_handshake_errors_total counter
apiserver_tls_handshake_errors_total 7
# HELP authenticated_user_requests [ALPHA] Counter of authenticated requests broken out by username.
# TYPE authenticated_user_requests counter
authenticated_user_requests{username="other"} 9585
# HELP authentication_attempts [ALPHA] Counter of authenticated attempts.
# TYPE authentication_attempts counter
authentication_attempts{result="error"} 6
authentication_attempts{result="success"} 9585
# HELP authentication_duration_seconds [ALPHA] Authentication duration in seconds broken out by result.
# TYPE authentication_duration_seconds histogram
authentication_duration_seconds_bucket{result="error",le="0.001"} 0
authentication_duration_seconds_bucket{result="error",le="0.002"} 0
authentication_duration_seconds_bucket{result="error",le="0.004"} 1
authentication_duration_seconds_bucket{result="error",le="0.008"} 4
authentication_duration_seconds_bucket{result="error",le="0.016"} 4
authentication_duration_seconds_bucket{result="error",le="0.032"} 5
authentication_duration_seconds_bucket{result="error",le="0.064"} 5
authentication_duration_seconds_bucket{result="error",le="0.128"} 5
authentication_duration_seconds_bucket{result="error",le="0.256"} 5
authentication_duration_seconds_bucket{result="error",le="0.512"} 5
authentication_duration_seconds_bucket{result="error",le="1.024"} 5
authentication_duration_seconds_bucket{result="error",le="2.048"} 5
authentication_duration_seconds_bucket{result="error",le="4.096"} 5
authentication_duration_seconds_bucket{result="error",le="8.192"} 5
authentication_duration_seconds_bucket{result="error",le="16.384"} 6
authentication_duration_seconds_bucket{result="error",le="+Inf"} 6
authentication_duration_seconds_sum{result="error"} 9.045682922
authentication_duration_seconds_count{result="error"} 6
authentication_duration_seconds_bucket{result="success",le="0.001"} 2744
authentication_duration_seconds_bucket{result="success",le="0.002"} 3532
authentication_duration_seconds_bucket{result="success",le="0.004"} 4584
authentication_duration_seconds_bucket{result="success",le="0.008"} 6088
authentication_duration_seconds_bucket{result="success",le="0.016"} 7738
authentication_duration_seconds_bucket{result="success",le="0.032"} 8601
authentication_duration_seconds_bucket{result="success",le="0.064"} 9097
authentication_duration_seconds_bucket{result="success",le="0.128"} 9389
authentication_duration_seconds_bucket{result="success",le="0.256"} 9484
authentication_duration_seconds_bucket{result="success",le="0.512"} 9542
authentication_duration_seconds_bucket{result="success",le="1.024"} 9563
authentication_duration_seconds_bucket{result="success",le="2.048"} 9573
authentication_duration_seconds_bucket{result="success",le="4.096"} 9581
authentication_duration_seconds_bucket{result="success",le="8.192"} 9585
authentication_duration_seconds_bucket{result="success",le="16.384"} 9585
authentication_duration_seconds_bucket{result="success",le="+Inf"} 9585
authentication_duration_seconds_sum{result="success"} 208.885888848
authentication_duration_seconds_count{result="success"} 9585
# HELP authentication_token_cache_active_fetch_count [ALPHA] 
# TYPE authentication_token_cache_active_fetch_count gauge
authentication_token_cache_active_fetch_count{status="blocked"} 0
authentication_token_cache_active_fetch_count{status="in_flight"} 0
# HELP authentication_token_cache_fetch_total [ALPHA] 
# TYPE authentication_token_cache_fetch_total counter
authentication_token_cache_fetch_total{status="error"} 5
authentication_token_cache_fetch_total{status="ok"} 282
# HELP authentication_token_cache_request_duration_seconds [ALPHA] 
# TYPE authentication_token_cache_request_duration_seconds histogram
authentication_token_cache_request_duration_seconds_bucket{status="hit",le="0.005"} 1
authentication_token_cache_request_duration_seconds_bucket{status="hit",le="0.01"} 1
authentication_token_cache_request_duration_seconds_bucket{status="hit",le="0.025"} 1
authentication_token_cache_request_duration_seconds_bucket{status="hit",le="0.05"} 1
authentication_token_cache_request_duration_seconds_bucket{status="hit",le="0.1"} 1
authentication_token_cache_request_duration_seconds_bucket{status="hit",le="0.25"} 1
authentication_token_cache_request_duration_seconds_bucket{status="hit",le="0.5"} 1
authentication_token_cache_request_duration_seconds_bucket{status="hit",le="1"} 1
authentication_token_cache_request_duration_seconds_bucket{status="hit",le="2.5"} 1
authentication_token_cache_request_duration_seconds_bucket{status="hit",le="5"} 1
authentication_token_cache_request_duration_seconds_bucket{status="hit",le="10"} 1
authentication_token_cache_request_duration_seconds_bucket{status="hit",le="+Inf"} 1
authentication_token_cache_request_duration_seconds_sum{status="hit"} 0
authentication_token_cache_request_duration_seconds_count{status="hit"} 1
authentication_token_cache_request_duration_seconds_bucket{status="miss",le="0.005"} 5
authentication_token_cache_request_duration_seconds_bucket{status="miss",le="0.01"} 17
authentication_token_cache_request_duration_seconds_bucket{status="miss",le="0.025"} 136
authentication_token_cache_request_duration_seconds_bucket{status="miss",le="0.05"} 221
authentication_token_cache_request_duration_seconds_bucket{status="miss",le="0.1"} 251
authentication_token_cache_request_duration_seconds_bucket{status="miss",le="0.25"} 269
authentication_token_cache_request_duration_seconds_bucket{status="miss",le="0.5"} 277
authentication_token_cache_request_duration_seconds_bucket{status="miss",le="1"} 281
authentication_token_cache_request_duration_seconds_bucket{status="miss",le="2.5"} 285
authentication_token_cache_request_duration_seconds_bucket{status="miss",le="5"} 286
authentication_token_cache_request_duration_seconds_bucket{status="miss",le="10"} 287
authentication_token_cache_request_duration_seconds_bucket{status="miss",le="+Inf"} 287
authentication_token_cache_request_duration_seconds_sum{status="miss"} 32.419000000000025
authentication_token_cache_request_duration_seconds_count{status="miss"} 287
# HELP authentication_token_cache_request_total [ALPHA] 
# TYPE authentication_token_cache_request_total counter
authentication_token_cache_request_total{status="hit"} 1
authentication_token_cache_request_total{status="miss"} 287
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 3.0459e-05
go_gc_duration_seconds{quantile="0.25"} 7.7333e-05
go_gc_duration_seconds{quantile="0.5"} 0.000147584
go_gc_duration_seconds{quantile="0.75"} 0.000367708
go_gc_duration_seconds{quantile="1"} 0.010048333
go_gc_duration_seconds_sum 0.105061287
go_gc_duration_seconds_count 154
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 98
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.14.2"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 1.5939904e+07
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 8.42592216e+08
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 1.666846e+06
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 7.993691e+06
# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
# TYPE go_memstats_gc_cpu_fraction gauge
go_memstats_gc_cpu_fraction 5.75806851638038e-05
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 3.5986e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 1.5939904e+07
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 4.6800896e+07
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 1.896448e+07
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 94092
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 4.4048384e+07
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 6.5765376e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.630059846293577e+09
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 8.087783e+06
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 6944
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 16384
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 239768
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 278528
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 2.1376752e+07
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 813274
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 1.343488e+06
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 1.343488e+06
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 7.3482496e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 14
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 162.08
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 18
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 4.005888e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.63004349882e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 7.61020416e+08
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes -1
# HELP metrics_server_api_metric_freshness_seconds [ALPHA] Freshness of metrics exported
# TYPE metrics_server_api_metric_freshness_seconds histogram
metrics_server_api_metric_freshness_seconds_bucket{le="1"} 0
metrics_server_api_metric_freshness_seconds_bucket{le="1.364"} 0
metrics_server_api_metric_freshness_seconds_bucket{le="1.8604960000000004"} 0
metrics_server_api_metric_freshness_seconds_bucket{le="2.5377165440000007"} 0
metrics_server_api_metric_freshness_seconds_bucket{le="3.4614453660160014"} 0
metrics_server_api_metric_freshness_seconds_bucket{le="4.721411479245826"} 0
metrics_server_api_metric_freshness_seconds_bucket{le="6.440005257691307"} 0
metrics_server_api_metric_freshness_seconds_bucket{le="8.784167171490942"} 0
metrics_server_api_metric_freshness_seconds_bucket{le="11.981604021913647"} 0
metrics_server_api_metric_freshness_seconds_bucket{le="16.342907885890217"} 0
metrics_server_api_metric_freshness_seconds_bucket{le="22.291726356354257"} 0
metrics_server_api_metric_freshness_seconds_bucket{le="30.405914750067208"} 0
metrics_server_api_metric_freshness_seconds_bucket{le="41.47366771909167"} 2
metrics_server_api_metric_freshness_seconds_bucket{le="56.57008276884105"} 11
metrics_server_api_metric_freshness_seconds_bucket{le="77.16159289669919"} 11
metrics_server_api_metric_freshness_seconds_bucket{le="105.2484127110977"} 11
metrics_server_api_metric_freshness_seconds_bucket{le="143.55883493793726"} 11
metrics_server_api_metric_freshness_seconds_bucket{le="195.81425085534644"} 11
metrics_server_api_metric_freshness_seconds_bucket{le="267.09063816669254"} 11
metrics_server_api_metric_freshness_seconds_bucket{le="364.31163045936864"} 11
metrics_server_api_metric_freshness_seconds_bucket{le="+Inf"} 11
metrics_server_api_metric_freshness_seconds_sum 489.95776228799997
metrics_server_api_metric_freshness_seconds_count 11
# HELP metrics_server_kubelet_last_request_time_seconds [ALPHA] Time of last request performed to Kubelet API since unix epoch in seconds
# TYPE metrics_server_kubelet_last_request_time_seconds gauge
metrics_server_kubelet_last_request_time_seconds{node="kind-control-plane"} 1.630059882e+09
metrics_server_kubelet_last_request_time_seconds{node="kind-worker"} 1.630059882e+09
metrics_server_kubelet_last_request_time_seconds{node="kind-worker2"} 1.630059882e+09
# HELP metrics_server_kubelet_request_duration_seconds [ALPHA] Duration of requests to Kubelet API in seconds
# TYPE metrics_server_kubelet_request_duration_seconds histogram
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-control-plane",le="0.005"} 0
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-control-plane",le="0.01"} 0
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-control-plane",le="0.025"} 2
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-control-plane",le="0.05"} 35
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-control-plane",le="0.1"} 116
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-control-plane",le="0.25"} 228
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-control-plane",le="0.5"} 257
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-control-plane",le="1"} 267
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-control-plane",le="2.5"} 273
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-control-plane",le="5"} 274
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-control-plane",le="10"} 274
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-control-plane",le="+Inf"} 274
metrics_server_kubelet_request_duration_seconds_sum{node="kind-control-plane"} 54.26867034999995
metrics_server_kubelet_request_duration_seconds_count{node="kind-control-plane"} 274
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker",le="0.005"} 0
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker",le="0.01"} 0
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker",le="0.025"} 0
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker",le="0.05"} 22
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker",le="0.1"} 81
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker",le="0.25"} 222
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker",le="0.5"} 253
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker",le="1"} 263
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker",le="2.5"} 272
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker",le="5"} 274
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker",le="10"} 274
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker",le="+Inf"} 274
metrics_server_kubelet_request_duration_seconds_sum{node="kind-worker"} 63.71151360599999
metrics_server_kubelet_request_duration_seconds_count{node="kind-worker"} 274
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker2",le="0.005"} 0
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker2",le="0.01"} 0
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker2",le="0.025"} 0
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker2",le="0.05"} 12
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker2",le="0.1"} 61
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker2",le="0.25"} 206
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker2",le="0.5"} 246
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker2",le="1"} 262
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker2",le="2.5"} 271
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker2",le="5"} 274
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker2",le="10"} 274
metrics_server_kubelet_request_duration_seconds_bucket{node="kind-worker2",le="+Inf"} 274
metrics_server_kubelet_request_duration_seconds_sum{node="kind-worker2"} 75.39053856299998
metrics_server_kubelet_request_duration_seconds_count{node="kind-worker2"} 274
# HELP metrics_server_kubelet_request_total [ALPHA] Number of requests sent to Kubelet API
# TYPE metrics_server_kubelet_request_total counter
metrics_server_kubelet_request_total{success="true"} 822
# HELP metrics_server_manager_tick_duration_seconds [ALPHA] The total time spent collecting and storing metrics in seconds.
# TYPE metrics_server_manager_tick_duration_seconds histogram
metrics_server_manager_tick_duration_seconds_bucket{le="0.005"} 0
metrics_server_manager_tick_duration_seconds_bucket{le="0.01"} 0
metrics_server_manager_tick_duration_seconds_bucket{le="0.025"} 0
metrics_server_manager_tick_duration_seconds_bucket{le="0.05"} 1
metrics_server_manager_tick_duration_seconds_bucket{le="0.1"} 31
metrics_server_manager_tick_duration_seconds_bucket{le="0.25"} 195
metrics_server_manager_tick_duration_seconds_bucket{le="0.5"} 243
metrics_server_manager_tick_duration_seconds_bucket{le="1"} 260
metrics_server_manager_tick_duration_seconds_bucket{le="2.5"} 271
metrics_server_manager_tick_duration_seconds_bucket{le="5"} 274
metrics_server_manager_tick_duration_seconds_bucket{le="10"} 274
metrics_server_manager_tick_duration_seconds_bucket{le="35"} 274
metrics_server_manager_tick_duration_seconds_bucket{le="60"} 274
metrics_server_manager_tick_duration_seconds_bucket{le="90"} 274
metrics_server_manager_tick_duration_seconds_bucket{le="120"} 274
metrics_server_manager_tick_duration_seconds_bucket{le="+Inf"} 274
metrics_server_manager_tick_duration_seconds_sum 83.295741823
metrics_server_manager_tick_duration_seconds_count 274
# HELP metrics_server_storage_points [ALPHA] Number of metrics points stored.
# TYPE metrics_server_storage_points gauge
metrics_server_storage_points{type="container"} 49
metrics_server_storage_points{type="node"} 3
```
</details>