### PR TITLE
prd cluster に dreamkast-releasebot をデプロイ

### DIFF
--- a/manifests/app/argocd-apps/production/dreamkast-releasebot.yaml
+++ b/manifests/app/argocd-apps/production/dreamkast-releasebot.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dreamkast-releasebot
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion
+spec:
+  destination:
+    namespace: dreamkast-releasebot
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: manifests/app/dreamkast-releasebot/overlays/development
+    repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true


### PR DESCRIPTION
* fix #795
    * dev cluster だけじゃなく prd cluster からも dreamkast-releasebot を消してしまったので、 prd にのみデプロイし直し