### PR TITLE
SQSの設定からコンテンツに基づく重複排除設定を無効にする

### DIFF
--- a/cfn/sqs.yaml
+++ b/cfn/sqs.yaml
@@ -18,7 +18,7 @@ Resources:
   SQS:
     Type: AWS::SQS::Queue
     Properties:
-      ContentBasedDeduplication: True
+      ContentBasedDeduplication: False
       DelaySeconds: 10
       FifoQueue: True
       MessageRetentionPeriod: 60


### PR DESCRIPTION
連続で同じメッセージを入れた場合に無効化されるので、少なくとも開発環境では不要と判断しました。