### PR TITLE
Job キューイングに失敗していた問題を修正

### DIFF
--- a/manifests/app/dreamkast/overlays/template/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/template/deployment-dreamkast.yaml
@@ -88,6 +88,8 @@ spec:
           value: "dreamkast-test-bucket"
         - name: S3_REGION
           value: ap-northeast-1
+        - name: SQS_MAIL_QUEUE_URL
+          value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/devMailQueue.fifo"
         - name: RAILS_MASTER_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast/pull/858 で環境変数の設定ミスによってキューイングに失敗している問題を修正

manifest 内で誤って initContainer だけに環境変数を設定していたため、定義を追加しました。