### PR TITLE
need RAILS_ENV

### DIFF
--- a/manifests/app/dreamkast/overlays/production/main/cronjob.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/cronjob.yaml
@@ -89,6 +89,8 @@ spec:
                 - -c
                 - bundle exec rake util:post_left_idea_issues_to_slack
               env:
+                - name: RAILS_ENV
+                  value: "production"
                 - name: SLACK_CHANNEL_NAME
                   value: "#cndt2021-notification"
                 - name: SLACK_WEBHOOK_URL


### PR DESCRIPTION

```
~ $ k logs post-left-idea-issues-to-slack-27210300-9rtdp
/usr/local/lib/ruby/2.7.0/net/protocol.rb:66: warning: already initialized constant Net::ProtocRetryError
/usr/local/bundle/gems/net-protocol-0.1.0/lib/net/protocol.rb:66: warning: previous definition of ProtocRetryError was here
/usr/local/lib/ruby/2.7.0/net/protocol.rb:206: warning: already initialized constant Net::BufferedIO::BUFSIZE
/usr/local/bundle/gems/net-protocol-0.1.0/lib/net/protocol.rb:206: warning: previous definition of BUFSIZE was here
/usr/local/lib/ruby/2.7.0/net/protocol.rb:503: warning: already initialized constant Net::NetPrivate::Socket
/usr/local/bundle/gems/net-protocol-0.1.0/lib/net/protocol.rb:503: warning: previous definition of Socket was here
config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true

rake aborted!
ActiveRecord::AdapterNotSpecified: The `production,` database is not configured for the `production,` environment.

Available databases configurations are:

default
development
test
production
/usr/local/bundle/gems/activerecord-6.0.3.1/lib/active_record/connection_adapters/connection_specification.rb:250:in `resolve_symbol_connection'
/usr/local/bundle/gems/activerecord-6.0.3.1/lib/active_record/connection_adapters/connection_specification.rb:218:in `resolve_connection'
/usr/local/bundle/gems/activerecord-6.0.3.1/lib/active_record/connection_adapters/connection_specification.rb:139:in `resolve'
/usr/local/bundle/gems/activerecord-6.0.3.1/lib/active_record/connection_handling.rb:170:in `resolve_config_for_connection'
/usr/local/bundle/gems/activerecord-6.0.3.1/lib/active_record/connection_handling.rb:50:in `establish_connection'
/usr/local/bundle/gems/activerecord-6.0.3.1/lib/active_record/railtie.rb:201:in `block (2 levels) in <class:Railtie>'
/usr/local/bundle/gems/activesupport-6.0.3.1/lib/active_support/lazy_load_hooks.rb:71:in `class_eval'
/usr/local/bundle/gems/activesupport-6.0.3.1/lib/active_support/lazy_load_hooks.rb:71:in `block in execute_hook'
/usr/local/bundle/gems/activesupport-6.0.3.1/lib/active_support/lazy_load_hooks.rb:61:in `with_execution_control'
/usr/local/bundle/gems/activesupport-6.0.3.1/lib/active_support/lazy_load_hooks.rb:66:in `execute_hook'
/usr/local/bundle/gems/activesupport-6.0.3.1/lib/active_support/lazy_load_hooks.rb:43:in `block in on_load'
/usr/local/bundle/gems/activesupport-6.0.3.1/lib/active_support/lazy_load_hooks.rb:42:in `each'
/usr/local/bundle/gems/activesupport-6.0.3.1/lib/active_support/lazy_load_hooks.rb:42:in `on_load'
/usr/local/bundle/gems/activerecord-6.0.3.1/lib/active_record/railtie.rb:198:in `block in <class:Railtie>'
/usr/local/bundle/gems/railties-6.0.3.1/lib/rails/initializable.rb:32:in `instance_exec'
/usr/local/bundle/gems/railties-6.0.3.1/lib/rails/initializable.rb:32:in `run'
/usr/local/bundle/gems/railties-6.0.3.1/lib/rails/initializable.rb:61:in `block in run_initializers'
/usr/local/bundle/gems/railties-6.0.3.1/lib/rails/initializable.rb:60:in `run_initializers'
/usr/local/bundle/gems/railties-6.0.3.1/lib/rails/application.rb:363:in `initialize!'
/app/config/environment.rb:5:in `<main>'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
/usr/local/bundle/gems/zeitwerk-2.3.0/lib/zeitwerk/kernel.rb:23:in `require'
/usr/local/bundle/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:324:in `block in require'
/usr/local/bundle/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:291:in `load_dependency'
/usr/local/bundle/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:324:in `require'
/usr/local/bundle/gems/railties-6.0.3.1/lib/rails/application.rb:339:in `require_environment!'
/usr/local/bundle/gems/railties-6.0.3.1/lib/rails/application.rb:523:in `block in run_tasks_blocks'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
Tasks: TOP => util:post_left_idea_issues_to_slack => environment
(See full trace by running task with --trace)
I, [2021-09-26T01:01:58.541872 #6]  INFO -- sentry: ** [Raven] Raven 3.0.0 configured not to capture errors: DSN not set
```