### PR TITLE
staging の kustomization に mail-worker を追加

### DIFF
--- a/manifests/app/dreamkast/overlays/staging/main/kustomization.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - ../../../base/
 patchesStrategicMerge:
 - deployment-dreamkast.yaml
+- deployment-mail-worker.yaml
 images:
 - name: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ecs
   newTag: 3c720bd609aed950874226ff8d407721afd23a6b


### PR DESCRIPTION
kustomization に mail-worker が記述されておらず不十分な状態で動作しており、Podが上手く作成できない不具合を解消