### PR TITLE
dev: update grafana from 8.1.5 to 8.1.6

### DIFF
--- a/manifests/argocd-apps/dev/grafana.yaml
+++ b/manifests/argocd-apps/dev/grafana.yaml
@@ -52,6 +52,8 @@ spec:
               gnetId: 11265
               revision: 2
       parameters:
+      - name: image.tag
+        value: "8.1.6"
       - name: persistence.enabled
         value: "true"
   syncPolicy:


### PR DESCRIPTION
https://grafana.com/blog/2021/10/05/grafana-7.5.11-and-8.1.6-released-with-critical-security-fix/