### PR TITLE
GrafanaにOAuth2で認証してログインできるようにする

### DIFF
--- a/manifests/argocd-apps/dev/grafana-secret.yaml
+++ b/manifests/argocd-apps/dev/grafana-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: 'kubernetes-client.io/v1'
+kind: ExternalSecret
+metadata:
+  name: grafana-secret
+  namespace: monitoring
+spec:
+  backendType: secretsManager
+  data:
+    - key: GrafanaAuth0
+      name: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+      property: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET

--- a/manifests/argocd-apps/dev/grafana.yaml
+++ b/manifests/argocd-apps/dev/grafana.yaml
@@ -52,7 +52,7 @@ spec:
               gnetId: 11265
               revision: 2
         envFromSecret: grafana-secret
-        grafana.ini:         
+        grafana.ini:
           auth.generic_oauth:
             enabled: true
             allow_sign_up: true
@@ -64,6 +64,8 @@ spec:
             auth_url: https://dreamkast.us.auth0.com/authorize
             token_url: https://dreamkast.us.auth0.com/oauth/token
             api_url: https://dreamkast.us.auth0.com/userinfo
+            role_attribute_strict: true
+            role_attribute_path: contains("https://cloudnativedays.jp/roles", 'CNDT2021-Admin') && 'Admin'
       parameters:
       - name: persistence.enabled
         value: "true"

--- a/manifests/argocd-apps/dev/grafana.yaml
+++ b/manifests/argocd-apps/dev/grafana.yaml
@@ -51,6 +51,19 @@ spec:
             Amazon EC2:
               gnetId: 11265
               revision: 2
+        envFromSecret: grafana-secret
+        grafana.ini:         
+          auth.generic_oauth:
+            enabled: true
+            allow_sign_up: true
+            team_ids:
+            allowed_organizations:
+            name: Auth0
+            client_id: 61c91hIk6j8dz2RAaNytOyHFgyKqilTX
+            scopes: openid profile email
+            auth_url: https://dreamkast.us.auth0.com/authorize
+            token_url: https://dreamkast.us.auth0.com/oauth/token
+            api_url: https://dreamkast.us.auth0.com/userinfo
       parameters:
       - name: persistence.enabled
         value: "true"

--- a/manifests/argocd-apps/prd/grafana.yaml
+++ b/manifests/argocd-apps/prd/grafana.yaml
@@ -52,7 +52,7 @@ spec:
               gnetId: 11265
               revision: 2
         envFromSecret: grafana-secret
-        grafana.ini:         
+        grafana.ini:
           auth.generic_oauth:
             enabled: true
             allow_sign_up: true
@@ -64,6 +64,8 @@ spec:
             auth_url: https://dreamkast.us.auth0.com/authorize
             token_url: https://dreamkast.us.auth0.com/oauth/token
             api_url: https://dreamkast.us.auth0.com/userinfo
+            role_attribute_strict: true
+            role_attribute_path: contains("https://cloudnativedays.jp/roles", 'CNDT2021-Admin') && 'Admin'
       parameters:
       - name: persistence.enabled
         value: "true"

--- a/manifests/argocd-apps/prd/grafana.yaml
+++ b/manifests/argocd-apps/prd/grafana.yaml
@@ -51,6 +51,19 @@ spec:
             Amazon EC2:
               gnetId: 11265
               revision: 2
+        envFromSecret: grafana-secret
+        grafana.ini:         
+          auth.generic_oauth:
+            enabled: true
+            allow_sign_up: true
+            team_ids:
+            allowed_organizations:
+            name: Auth0
+            client_id: 61c91hIk6j8dz2RAaNytOyHFgyKqilTX
+            scopes: openid profile email
+            auth_url: https://dreamkast.us.auth0.com/authorize
+            token_url: https://dreamkast.us.auth0.com/oauth/token
+            api_url: https://dreamkast.us.auth0.com/userinfo
       parameters:
       - name: persistence.enabled
         value: "true"


### PR DESCRIPTION
resolve #752

# 概要
Auth0に登録したユーザで`CNDT2021-Admin`のRolesに入っているメンバーのみGrafanaにログインできるようにする

# 確認したこと
- ExternalSecretを作成して、AWS Secrets ManagerからSecretが取得できていること
- GrafanaにAuth0でログインしたときAdminの権限が付与されていること
  - `role_attribute_path`を設定して実現する

 - `role_attribute_path`で明示的に権限を指定していないとき`role_attribute_strict = true`を設定することで、ログインできなくなること
    - Grafanaの権限を指定していないときはViewerの権限がデフォルトで設定される仕様
    - https://grafana.com/docs/grafana/latest/auth/generic-oauth/#role-mapping 

# 作業メモ
## `role_attribute_path` について

ログレベルをinfoからdebugに変更する
```yaml
grafana.ini:
  log:
    level: debug
```

grafanaにAuth0でログインする & Podのログ(k -n monitoring logs -f $POD_NAME)を確認すると、userinfoからのレスポンスが取得できる
```
t=2021-10-09T11:20:47+0000 lvl=dbug msg="Received user info response from API" logger=oauth.generic_oauth raw_json="{\"sub\":\"",\"given_name\":\"\",~~~" data="Name: , Displayname: , Login: , Username: , Email: , Upn: , Attributes: map[]"
```
https://auth0.com/docs/api/authentication#user-profile

`raw_json`を整形すると以下のようになり、[grafanaのjmespath example](https://grafana.com/docs/grafana/latest/auth/generic-oauth/#jmespath-examples) と [jmespathのサイト](https://jmespath.org/?)から `role_attribute_path`に設定するクエリを作成する
```json
{
  "sub": "xxx",
  "given_name": "xxx",
  "family_name": "xxx",
  "nickname": "xxx",
  "name": "xxx",
  "picture": "https://lh3.googleusercontent.com/xxx",
  "locale": "xxx",
  "updated_at": "2021-10-06T13:29:12.984Z",
  "email": "xxx",
  "email_verified": true,
  "https://cloudnativedays.jp/roles": [
    "CICD2021-Admin",
    "CNDT2021-Admin"
  ],
  "https://cloudnativedays.jp/claims/groups": [
    "dreamkast-core"
  ]
}
```

![スクリーンショット 2021-10-10 14 59 15](https://user-images.githubusercontent.com/24477226/136684459-3bd8d4fa-fa8b-44c4-8abd-6fca78fb2e34.png)

## 参考
- https://blog.dahanne.net/2020/04/15/integrating-auth0-oidc-oauth-2-with-authorization-groups-and-roles/
- https://community.grafana.com/t/role-is-not-attached-to-user-when-using-role-attribute-path-for-generic-oauth/25689

