### PR TITLE
dev: fix a invalid value of grafana-dashboards-default

### DIFF
--- a/manifests/argocd-apps/dev/grafana.yaml
+++ b/manifests/argocd-apps/dev/grafana.yaml
@@ -51,7 +51,7 @@ spec:
             Amazon EC2:
               gnetId: 11265
               revision: 2
-            Kubernetes Pod:
+            Kubernetes-Pod:
               json: |
                 {
                   "annotations": {


### PR DESCRIPTION
自作ダッシュボード名に半角スペースは使えませんでした。

> ConfigMap "grafana-dashboards-default" is invalid: data[Kubernetes Pod.json]: Invalid value: "Kubernetes Pod.json": a valid config key must consist of alphanumeric characters, '-', '_' or '.' (e.g. 'key.name', or 'KEY_NAME', or 'key-name', regex used for validation is '[-._a-zA-Z0-9]+')
![sync-failed](https://user-images.githubusercontent.com/4710215/137624534-82f61e12-bf9c-41c2-b4a0-edc50dc99a0a.png)


