### PR TITLE
Update NLB annotation

### DIFF
--- a/manifests/infra/contour/overlays/development/contour.yaml
+++ b/manifests/infra/contour/overlays/development/contour.yaml
@@ -2923,7 +2923,8 @@ kind: Service
 metadata:
   name: envoy
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
+    service.beta.kubernetes.io/aws-load-balancer-type: "external"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
   namespace: projectcontour
 spec:
   externalTrafficPolicy: Local


### PR DESCRIPTION
Ref. https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/service/nlb/#ip-mode_1

nlb-ipはdeprecatedになる予定

本来はbaseも書き換える必要はあるが、一旦Devだけに導入して挙動を見たいのでここだけ書き換える。本番はあとで書き換える予定。