### PR TITLE
dev: add manually managed grafana dashboards

### DIFF
--- a/manifests/argocd-apps/dev/grafana.yaml
+++ b/manifests/argocd-apps/dev/grafana.yaml
@@ -51,6 +51,15 @@ spec:
             Amazon EC2:
               gnetId: 11265
               revision: 2
+            Cluster Monitoring for Kubernetes:
+              gnetId: 10000
+              revision: 1
+            Kubernetes Cluster (Prometheus):
+              gnetId: 6417
+              revision: 1
+            Logging Dashboard via Loki:
+              gnetId: 12611
+              revision: 1
             Kubernetes-Pod:
               json: |
                 {


### PR DESCRIPTION
#1056 解決のため、grafanaをStatefulSetにしたらargocd-appsで管理していないダッシュボードが吹き飛びました。
No dataだらけのものも含め、prodにあるダッシュボードをdevに作成します。

動作確認できたら、prodにダッシュボード追加とStatefulSet移行をまとめてPRします。

@inductor `Contour - HTTPProxy`ダッシュボードはどうやって作ったかわかります？