### PR TITLE
allow PassRole

### DIFF
--- a/cfn/eks-nodes.yaml
+++ b/cfn/eks-nodes.yaml
@@ -142,6 +142,13 @@ Resources:
             Statement:
               - Effect: "Allow"
                 Action:
+                  - "iam:PassRole"
+                Resource: "*"
+          PolicyName: "AllowPassRolePolicy"
+        - PolicyDocument:
+            Statement:
+              - Effect: "Allow"
+                Action:
                   - "autoscaling:DescribeAutoScalingGroups"
                   - "autoscaling:DescribeAutoScalingInstances"
                   - "autoscaling:DescribeLaunchConfigurations"


### PR DESCRIPTION
DreamkastからMediaLive Channelを作るためにはインスタンスプロファイルにPassRoleが必要なので追加します。