### PR TITLE
dev: bump grafana from 8.1.6 to 8.2.3 to fix CVE-2021-41174

### DIFF
--- a/manifests/argocd-apps/dev/grafana.yaml
+++ b/manifests/argocd-apps/dev/grafana.yaml
@@ -1512,7 +1512,7 @@ spec:
             role_attribute_path: contains("https://cloudnativedays.jp/roles", 'CNDT2021-Admin') && 'Admin'
       parameters:
       - name: image.tag
-        value: "8.1.6"
+        value: "8.2.3"
       - name: persistence.enabled
         value: "true"
       - name: persistence.type


### PR DESCRIPTION
Helm Chartのアップデートもあるが、脆弱性対応としてはイメージのアップデートのみ行う。
https://grafana.com/blog/2021/11/03/grafana-8.2.3-released-with-medium-severity-security-fix-cve-2021-41174-grafana-xss/