### PR TITLE
fix sqs queue name

### DIFF
--- a/manifests/app/dreamkast/overlays/template/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/template/deployment-dreamkast.yaml
@@ -43,7 +43,7 @@ spec:
         - name: S3_REGION
           value: ap-northeast-1
         - name: SQS_MAIL_QUEUE_URL
-          value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/devMailQueue.fifo"
+          value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-devMailQueue.fifo"
         - name: DREAMKAST_NAMESPACE
           valueFrom:
             fieldRef:

--- a/manifests/app/dreamkast/overlays/template/deployment-mail-worker.yaml
+++ b/manifests/app/dreamkast/overlays/template/deployment-mail-worker.yaml
@@ -31,7 +31,7 @@ spec:
         - name: RAILS_ENV
           value: "production"
         - name: AWS_REGION
-          value: "ap-northeast-1"  
+          value: "ap-northeast-1"
         - name: MYSQL_HOST
           value: "dreamkast-mysql"
         - name: REDIS_URL
@@ -43,7 +43,7 @@ spec:
         - name: S3_REGION
           value: ap-northeast-1
         - name: SQS_MAIL_QUEUE_URL
-          value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/devMailQueue.fifo"
+          value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-devMailQueue.fifo"
         - name: RAILS_MASTER_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
sqs の stack を更新した際に以前のキュー名の変更が適用されてしまい review_app でうまく起動しなくなっていたので修正

* old では `devQueue` だったが current では `dreamkast-devQueue` が正になっている
* cfn が更新されていたが、スタックは更新されていなかったため顕在化しなかった
* chat キューを作るためにスタックを更新したので prefix の変更が環境にも適用された
* stg/prod では prefix が入っているため影響していない
