### PR TITLE
Add DREAMKAST_NAMESPACE env into reviewapp

### DIFF
--- a/manifests/reviewapps/dreamkast.yaml
+++ b/manifests/reviewapps/dreamkast.yaml
@@ -341,6 +341,10 @@ spec:
                 value: ap-northeast-1
               - name: SQS_MAIL_QUEUE_URL
                 value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/devMailQueue.fifo"
+              - name: DREAMKAST_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
               - name: RAILS_MASTER_KEY
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
ref: #1165

Reviewapp operatorへの移行が過渡期なのもあって、こちらのほうにも入れないとDkのReview appに反映されないです