### PR TITLE
modify jaeger chart name

### DIFF
--- a/manifests/argocd-apps/dev/jaeger.yaml
+++ b/manifests/argocd-apps/dev/jaeger.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: jaeger
+  name: jaeger-tracing
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion
@@ -12,7 +12,7 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    chart: jaeger
+    chart: jaeger-tracing
     repoURL: https://jaegertracing.github.io/helm-charts
     targetRevision: 0.51.3
     helm:


### PR DESCRIPTION
https://github.com/helm/charts/issues/13077 によると

> If you install jaeger chart with name jaeger, environment variable JAEGER_AGENT_PORT will be automatically created by Kubernetes (as string) and jaeger-client-go expects integer (just the port number, not url) under the same name so it is going to fail. The easiest way to fix the problem would be to install jaeger under some different name

ということなので、chartの名前を変えて再度デプロイします