### PR TITLE
dev: manage aws-ebs-csi-driver by argocd

### DIFF
--- a/manifests/argocd-apps/dev/aws-ebs-csi-driver.yaml
+++ b/manifests/argocd-apps/dev/aws-ebs-csi-driver.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aws-ebs-csi-driver
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion
+spec:
+  destination:
+    namespace: kube-system
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    chart: aws-ebs-csi-driver
+    repoURL: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+    targetRevision: 2.4.0
+    helm:
+      parameters:
+      - name: controller.region
+        value: ap-northeast-1
+      - name: controller.serviceAccount.create
+        value: "false"
+      - name: controller.serviceAccount.name
+        value: ebs-csi-controller-sa
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true


### PR DESCRIPTION
ref #1243

dev-clusterの設定
```shell
helm get values aws-ebs-csi-driver -n kube-system
```
```yaml
USER-SUPPLIED VALUES:
controller:
  region: ap-northeast-1
  serviceAccount:
    create: false
    name: ebs-csi-controller-sa
```