### PR TITLE
Make prometheus volume persistent

### DIFF
--- a/manifests/infra/prometheus/base/prometheus.yaml
+++ b/manifests/infra/prometheus/base/prometheus.yaml
@@ -159,6 +159,12 @@ spec:
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
   version: 2.26.0
+  storage:
+    volumeClaimTemplate:
+      spec:
+        resources:
+          requests:
+            storage: 10Gi
 ---
 # prometheus-service.yaml
 apiVersion: v1


### PR DESCRIPTION
現在のリソースステータス

```
(base) ry@mbp2020 Desktop % k get pods,pvc                                                       
NAME                                            READY   STATUS    RESTARTS   AGE
pod/elasticsearch-master-0                      1/1     Running   0          34h
pod/elasticsearch-master-1                      1/1     Running   0          34h
pod/elasticsearch-master-2                      1/1     Running   0          34h
pod/grafana-0                                   1/1     Running   0          35h
pod/jaeger-tracing-agent-29rfq                  1/1     Running   0          34h
pod/jaeger-tracing-agent-hm767                  1/1     Running   0          34h
pod/jaeger-tracing-agent-htnkq                  1/1     Running   0          34h
pod/jaeger-tracing-agent-jhxb9                  1/1     Running   0          34h
pod/jaeger-tracing-collector-5d996b4c44-r85n4   1/1     Running   4          34h
pod/jaeger-tracing-query-678564b779-vsrjd       2/2     Running   4          34h
pod/loki-0                                      1/1     Running   0          34h
pod/loki-promtail-7k6vb                         1/1     Running   0          35h
pod/loki-promtail-crjmb                         1/1     Running   0          5d12h
pod/loki-promtail-kh852                         1/1     Running   0          6d21h
pod/loki-promtail-n4n4m                         1/1     Running   0          6d21h
pod/node-exporter-h4g8f                         2/2     Running   0          5d12h
pod/node-exporter-hx25x                         2/2     Running   0          6d21h
pod/node-exporter-v8pfb                         2/2     Running   0          6d21h
pod/node-exporter-x2jqf                         2/2     Running   0          5d12h
pod/prometheus-k8s-0                            2/2     Running   0          14m
pod/prometheus-k8s-1                            2/2     Running   0          14m

NAME                                                                STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
persistentvolumeclaim/elasticsearch-master-elasticsearch-master-0   Bound    pvc-dbec77ae-e5cf-4558-a365-e09fd6f4f496   30Gi       RWO            ebs-sc         34h
persistentvolumeclaim/elasticsearch-master-elasticsearch-master-1   Bound    pvc-0f78d557-c381-4710-ae5c-d413334dcc1e   30Gi       RWO            ebs-sc         34h
persistentvolumeclaim/elasticsearch-master-elasticsearch-master-2   Bound    pvc-90216b16-ef6f-4399-b9e7-94a040ce0c47   30Gi       RWO            ebs-sc         34h
persistentvolumeclaim/prometheus-k8s-db-prometheus-k8s-0            Bound    pvc-7276aa8c-205f-441d-8568-38e821b4ee3d   10Gi       RWO            ebs-sc         14m
persistentvolumeclaim/prometheus-k8s-db-prometheus-k8s-1            Bound    pvc-9b71dcd3-4335-414f-a7c0-8f62b7a112e5   10Gi       RWO            ebs-sc         14m
persistentvolumeclaim/storage-grafana-0                             Bound    pvc-6d9f5e4d-0d2c-4a88-8a9d-c1079bbbd1fb   10Gi       RWO            ebs-sc         35h
persistentvolumeclaim/storage-loki-0                                Bound    pvc-44becd6e-393f-42db-bc3b-b62c331ed864   10Gi       RWO            ebs-sc         35h
```

適用前のdiff

```
(base) ry@mbp2020 Desktop % diff current-prometheus.yaml new-prometheus.yaml 
4,8d3
<   annotations:
<     kubectl.kubernetes.io/last-applied-configuration: |
<       {"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"annotations":{},"labels":{"app.kubernetes.io/component":"prometheus","app.kubernetes.io/name":"prometheus","app.kubernetes.io/part-of":"kube-prometheus","app.kubernetes.io/version":"2.26.0","argocd.argoproj.io/instance":"prometheus","prometheus":"k8s"},"name":"k8s","namespace":"monitoring"},"spec":{"alerting":{"alertmanagers":[{"apiVersion":"v2","name":"alertmanager-main","namespace":"monitoring","port":"web"}]},"externalLabels":{},"image":"quay.io/prometheus/prometheus:v2.26.0","nodeSelector":{"kubernetes.io/os":"linux"},"podMetadata":{"labels":{"app.kubernetes.io/component":"prometheus","app.kubernetes.io/name":"prometheus","app.kubernetes.io/part-of":"kube-prometheus","app.kubernetes.io/version":"2.26.0"}},"podMonitorNamespaceSelector":{},"podMonitorSelector":{},"probeNamespaceSelector":{},"probeSelector":{},"replicas":2,"resources":{"requests":{"memory":"400Mi"}},"ruleSelector":{"matchLabels":{"prometheus":"k8s","role":"alert-rules"}},"securityContext":{"fsGroup":2000,"runAsNonRoot":true,"runAsUser":1000},"serviceAccountName":"prometheus-k8s","serviceMonitorNamespaceSelector":{},"serviceMonitorSelector":{},"version":"2.26.0"}}
<   creationTimestamp: "2021-09-11T10:21:54Z"
<   generation: 3
14d8
<     argocd.argoproj.io/instance: prometheus
18,19d11
<   resourceVersion: "51771973"
<   uid: 0cb6b137-db5e-4063-8cf1-116f7420722a
56a49,54
>   storage:
>     volumeClaimTemplate:
>       spec:
>         resources:
>           requests:
>             storage: 10Gi
```