### PR TITLE
Changed argo' syncPolicy from manual  to auto-sync

### DIFF
--- a/manifests/argocd-apps/dev/prometheus.yaml
+++ b/manifests/argocd-apps/dev/prometheus.yaml
@@ -15,9 +15,8 @@ spec:
     path: manifests/infra/prometheus/overlays/development
     repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
     targetRevision: main
-  syncPolicy: {}
-#  syncPolicy:
-#    automated:
-#      prune: true
-#    syncOptions:
-#    - CreateNamespace=true
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true


### PR DESCRIPTION
# Fix ArgoCD setting

## Purpose of this pull request
Dev環境におけるArgoCDのsyncがmanualでの実施となっているため、Auto-syncに変更するための修正を実施。

This PR is to change Argo's syncPolicy from manual to auto-sync on developing environment.

## Background
PrometheusのManifestに一時的な変更を加えるために、ArgoCDのsyncPolicyをmanualに修正していた。

Due to fixing #1253, I've temporarily turned syncPolicy into manual.