### PR TITLE
Prometheus monitor

### DIFF
--- a/manifests/infra/prometheus/overlays/development/kustomization.yaml
+++ b/manifests/infra/prometheus/overlays/development/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.52.1/bundle.yaml
 - ../../base
+- service-monitor.yaml
 patchesStrategicMerge:
 - node-exporter.yaml
 - prometheus.yaml

--- a/manifests/infra/prometheus/overlays/development/service-monitor.yaml
+++ b/manifests/infra/prometheus/overlays/development/service-monitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prometheus-metrics
+  namespace: monitoring
+spec:
+  endpoints:
+  - path: /metrics
+    port: web
+  namespaceSelector:
+    matchNames:
+    - monitoring
+  selector:
+    matchLabels:
+      prometheus: k8s


### PR DESCRIPTION
## 目的
PrometheusのFilesystem使用率に関して現状の最大値を把握するため、モニタリングの定義を追加。

## 対象issue
#1253 #1252 #1265