### PR TITLE
dev: bump grafana from 8.2.3 to 8.3.1 to fix CVE-2021-43798

### DIFF
--- a/manifests/argocd-apps/dev/grafana.yaml
+++ b/manifests/argocd-apps/dev/grafana.yaml
@@ -1515,7 +1515,7 @@ spec:
             role_attribute_path: contains("https://cloudnativedays.jp/roles", 'CNDT2021-Admin') && 'Admin'
       parameters:
       - name: image.tag
-        value: "8.2.3"
+        value: "8.3.1"
       - name: persistence.enabled
         value: "true"
       - name: persistence.type


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Grafana in development environment will be updated to fix CVE-2021-43798, path traversal.
https://grafana.com/blog/2021/12/07/grafana-8.3.1-8.2.7-8.1.8-and-8.0.7-released-with-high-severity-security-fix/

8.2.7 would be better?

ref #1277

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
