### PR TITLE
Add namespace env on side jobs

### DIFF
--- a/manifests/app/dreamkast/overlays/production/main/cronjob.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/cronjob.yaml
@@ -38,6 +38,10 @@ spec:
                   value: "dreamkast-prd-bucket"
                 - name: S3_REGION
                   value: ap-northeast-1
+                - name: DREAMKAST_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 - name: RAILS_MASTER_KEY
                   valueFrom:
                     secretKeyRef:

--- a/manifests/app/dreamkast/overlays/production/main/deployment-mail-worker.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/deployment-mail-worker.yaml
@@ -46,6 +46,10 @@ spec:
           value: ap-northeast-1
         - name: SQS_MAIL_QUEUE_URL
           value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-prdMailQueue.fifo"
+        - name: DREAMKAST_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: RAILS_MASTER_KEY
           valueFrom:
             secretKeyRef:

--- a/manifests/app/dreamkast/overlays/production/main/viewer-count.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/viewer-count.yaml
@@ -36,6 +36,10 @@ spec:
                   value: ap-northeast-1
                 - name: SQS_MAIL_QUEUE_URL
                   value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-prdMailQueue.fifo"
+                - name: DREAMKAST_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 - name: RAILS_MASTER_KEY
                   valueFrom:
                     secretKeyRef:

--- a/manifests/app/dreamkast/overlays/staging/main/deployment-fifo-worker.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/deployment-fifo-worker.yaml
@@ -47,6 +47,10 @@ spec:
           value: ap-northeast-1
         - name: SQS_FIFO_QUEUE_URL
           value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-stgFifoQueue.fifo"
+        - name: DREAMKAST_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: RAILS_MASTER_KEY
           valueFrom:
             secretKeyRef:

--- a/manifests/app/dreamkast/overlays/staging/main/viewer-count.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/viewer-count.yaml
@@ -36,6 +36,10 @@ spec:
                   value: ap-northeast-1
                 - name: SQS_MAIL_QUEUE_URL
                   value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-stgMailQueue.fifo"
+                - name: DREAMKAST_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 - name: RAILS_MASTER_KEY
                   valueFrom:
                     secretKeyRef:

--- a/manifests/reviewapps/dreamkast-ui.yaml
+++ b/manifests/reviewapps/dreamkast-ui.yaml
@@ -498,6 +498,10 @@ spec:
                 value: https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-devFifoQueue.fifo
               - name: SQS_FIFO_QUEUE_URL
                 value: https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-devFifoQueue.fifo
+              - name: DREAMKAST_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
               - name: RAILS_MASTER_KEY
                 valueFrom:
                   secretKeyRef:
@@ -574,6 +578,10 @@ spec:
                         value: ap-northeast-1
                       - name: SQS_MAIL_QUEUE_URL
                         value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/devMailQueue.fifo"
+                      - name: DREAMKAST_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
                       - name: AWS_REGION
                         value: ap-northeast-1
                       - name: RAILS_MASTER_KEY

--- a/manifests/reviewapps/dreamkast.yaml
+++ b/manifests/reviewapps/dreamkast.yaml
@@ -498,6 +498,10 @@ spec:
                 value: https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-devFifoQueue.fifo
               - name: SQS_FIFO_QUEUE_URL
                 value: https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-devFifoQueue.fifo
+              - name: DREAMKAST_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
               - name: RAILS_MASTER_KEY
                 valueFrom:
                   secretKeyRef:
@@ -576,6 +580,10 @@ spec:
                         value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/devFifoQueue.fifo"
                       - name: AWS_REGION
                         value: ap-northeast-1
+                      - name: DREAMKAST_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
                       - name: RAILS_MASTER_KEY
                         valueFrom:
                           secretKeyRef:


### PR DESCRIPTION
# Description

`dreamkast-dev` is a default Jaeger service name that dreamkast sets if `DREAMKAST_NAMESPACE` is not specified.
We did not properly set this value for mail worker and batch jobs, and this PR covers it. 

Production Grafana currently recognizes those jobs as `dreamkast-dev`
<img width="266" alt="image" src="https://user-images.githubusercontent.com/20236173/145757365-184c815b-86ea-4826-b14e-160808b5a04f.png">


Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally applied, but this won't break anything as it just adds environment variable.

- [x] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
