### PR TITLE
Modify SQS parameters for low latency chat delivery

### DIFF
--- a/cfn/sqs.yaml
+++ b/cfn/sqs.yaml
@@ -19,7 +19,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       ContentBasedDeduplication: False
-      DelaySeconds: 10
+      DelaySeconds: 0
       FifoQueue: True
       MessageRetentionPeriod: 60
       QueueName: !Sub "${PJPrefix}MailQueue.fifo"
@@ -27,7 +27,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       ContentBasedDeduplication: False
-      DelaySeconds: 10
+      DelaySeconds: 0
       FifoQueue: True
       MessageRetentionPeriod: 60
       QueueName: !Sub "${PJPrefix}FifoQueue.fifo"


### PR DESCRIPTION
# Description

The `delaySeconds` parameter of the SQS queue is set to 10, which interferes with the real-time performance of chat, so fix it to 0.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
