### PR TITLE
Incraese Volume Size on production Prometheus

### DIFF
--- a/manifests/infra/prometheus/overlays/production/kustomization.yaml
+++ b/manifests/infra/prometheus/overlays/production/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - ../../base
 patchesStrategicMerge:
 - prometheus-crd.yaml
+- prometheus.yaml

--- a/manifests/infra/prometheus/overlays/production/prometheus.yaml
+++ b/manifests/infra/prometheus/overlays/production/prometheus.yaml
@@ -1,0 +1,13 @@
+# prometheus-prometheus.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: k8s
+  namespace: monitoring
+spec:
+  storage:
+    volumeClaimTemplate:
+      spec:
+        resources:
+          requests:
+            storage: 150Gi


### PR DESCRIPTION
# Description

Fixes a part of https://github.com/cloudnativedaysjp/dreamkast-infra/issues/1265

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I have checked backward/forward compatibility that may cause regarding this change.

```diff
diff -u -N /tmp/LIVE-1252176878/monitoring.coreos.com.v1.Prometheus.monitoring.k8s /tmp/MERGED-3422743700/monitoring.coreos.com.v1.Prometheus.monitoring.k8s
--- /tmp/LIVE-1252176878/monitoring.coreos.com.v1.Prometheus.monitoring.k8s     2021-12-15 22:38:07.966735730 +0900
+++ /tmp/MERGED-3422743700/monitoring.coreos.com.v1.Prometheus.monitoring.k8s   2021-12-15 22:38:07.966735730 +0900
@@ -5,13 +5,12 @@
     kubectl.kubernetes.io/last-applied-configuration: |
       {"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"annotations":{},"labels":{"app.kubernetes.io/component":"prometheus","app.kubernetes.io/name":"prometheus","app.kubernetes.io/part-of":"kube-prometheus","app.kubernetes.io/version":"2.31.1","argocd.argoproj.io/instance":"prometheus","prometheus":"k8s"},"name":"k8s","namespace":"monitoring"},"spec":{"alerting":{"alertmanagers":[{"apiVersion":"v2","name":"alertmanager-main","namespace":"monitoring","port":"web"}]},"enableFeatures":[],"externalLabels":{},"image":"quay.io/prometheus/prometheus:v2.31.1","nodeSelector":{"kubernetes.io/os":"linux"},"podMetadata":{"labels":{"app.kubernetes.io/component":"prometheus","app.kubernetes.io/name":"prometheus","app.kubernetes.io/part-of":"kube-prometheus","app.kubernetes.io/version":"2.31.1","prometheus":"k8s"}},"podMonitorNamespaceSelector":{},"podMonitorSelector":{},"probeNamespaceSelector":{},"probeSelector":{},"replicas":2,"resources":{"requests":{"memory":"400Mi"}},"ruleNamespaceSelector":{},"ruleSelector":{},"securityContext":{"fsGroup":2000,"runAsNonRoot":true,"runAsUser":1000},"serviceAccountName":"prometheus-k8s","serviceMonitorNamespaceSelector":{},"serviceMonitorSelector":{},"storage":{"volumeClaimTemplate":{"spec":{"resources":{"requests":{"storage":"10Gi"}}}}},"version":"2.31.1"}}
   creationTimestamp: "2021-10-03T08:56:16Z"
-  generation: 3
+  generation: 4
   labels:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.31.1
-    argocd.argoproj.io/instance: prometheus
     prometheus: k8s
   managedFields:
   - apiVersion: monitoring.coreos.com/v1
@@ -27,7 +26,6 @@
           f:app.kubernetes.io/name: {}
           f:app.kubernetes.io/part-of: {}
           f:app.kubernetes.io/version: {}
-          f:argocd.argoproj.io/instance: {}
           f:prometheus: {}
       f:spec:
         .: {}
@@ -77,13 +75,24 @@
               .: {}
               f:resources:
                 .: {}
-                f:requests:
-                  .: {}
-                  f:storage: {}
+                f:requests: {}
         f:version: {}
     manager: argocd-application-controller
     operation: Update
     time: "2021-12-02T14:51:11Z"
+  - apiVersion: monitoring.coreos.com/v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:spec:
+        f:storage:
+          f:volumeClaimTemplate:
+            f:spec:
+              f:resources:
+                f:requests:
+                  f:storage: {}
+    manager: kubectl-client-side-apply
+    operation: Update
+    time: "2021-12-15T13:38:07Z"
   name: k8s
   namespace: monitoring
   resourceVersion: "176856855"
@@ -129,5 +138,5 @@
       spec:
         resources:
           requests:
-            storage: 10Gi
+            storage: 150Gi
```

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
