### PR TITLE
Restart telegraf when updated configmap

### DIFF
--- a/manifests/infra/telegraf/base/deployment.yaml
+++ b/manifests/infra/telegraf/base/deployment.yaml
@@ -18,10 +18,14 @@ spec:
       containers:
         - image: telegraf
           name: telegraf
+          args:
+          - --config
+          - /etc/telegraf/telegraf.conf
+          - --watch-config
+          - inotify
           volumeMounts:
-            - mountPath: /etc/telegraf/telegraf.conf
+            - mountPath: /etc/telegraf/
               name: telegraf-config
-              subPath: telegraf.conf
               readOnly: true
           env:
           - name: CONF_ID


### PR DESCRIPTION
Fix cloudnativedaysjp/observability#12
1) add `--watch-config`
2) remove subpath as it will not automatically detect cm changes

Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/
> Note: A container using a ConfigMap as a subPath volume will not receive ConfigMap updates.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested locallly by changing `debug` flag in config. Verified file reloads occurs.

```
2021-12-21T14:21:45Z I! Config file modified
2021-12-21T14:21:45Z I! Reloading Telegraf config
2021-12-21T14:21:45Z D! [agent] Stopping service inputs
2021-12-21T14:21:45Z D! [agent] Input channel closed
2021-12-21T14:21:45Z I! [agent] Hang on, flushing any cached metrics before shutdown
2021-12-21T14:21:45Z D! [outputs.prometheus_client] Wrote batch of 115 metrics in 2.399497ms
2021-12-21T14:21:45Z D! [outputs.prometheus_client] Buffer fullness: 0 / 10000 metrics
2021-12-21T14:21:45Z I! [agent] Stopping running outputs
2021-12-21T14:21:45Z D! [agent] Stopped Successfully
2021-12-21T14:21:45Z I! Starting Telegraf 1.20.4
2021-12-21T14:21:45Z I! Config watcher started
2021-12-21T14:21:45Z I! Loaded inputs: github sql
2021-12-21T14:21:45Z I! Loaded aggregators:
2021-12-21T14:21:45Z I! Loaded processors:
2021-12-21T14:21:45Z I! Loaded outputs: prometheus_client
2021-12-21T14:21:45Z I! Tags enabled:
2021-12-21T14:21:45Z I! [agent] Config: Interval:30s, Quiet:false, Hostname:"", Flush Interval:30s
2021-12-21T14:21:45Z I! [outputs.prometheus_client] Listening on http://[::]:9273/metrics
```

