### PR TITLE
change role_attribute_strict from true to false

### DIFF
--- a/manifests/argocd-apps/dev/grafana.yaml
+++ b/manifests/argocd-apps/dev/grafana.yaml
@@ -1515,7 +1515,7 @@ spec:
             auth_url: https://dreamkast.us.auth0.com/authorize
             token_url: https://dreamkast.us.auth0.com/oauth/token
             api_url: https://dreamkast.us.auth0.com/userinfo
-            role_attribute_strict: true
+            role_attribute_strict: false
             role_attribute_path: contains("https://cloudnativedays.jp/roles", 'O11Y2022-Admin') && 'Admin'
       parameters:
       - name: image.tag


### PR DESCRIPTION
# Description

Change role_attribute_strict from true to false to give Grafana Viewer privileges to users who have not explicitly assigned a Role.

Related Issue: https://github.com/cloudnativedaysjp/dreamkast-infra/issues/1279

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Access [Grafana in Dev Environment](https://grafana.dev.cloudnativedays.jp/) with an account that has not been assigned a Role, and confirm that the user can view the dashboard.
