### PR TITLE
アーカイブ録画機能実装のため、NodeInstanceRoleがMediaPackageにアクセスできるようにします

### DIFF
--- a/cfn/eks-nodes-bottlerocket.yaml
+++ b/cfn/eks-nodes-bottlerocket.yaml
@@ -95,6 +95,7 @@ Resources:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSQSFullAccess'
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchSyntheticsReadOnlyAccess'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AWSElementalMediaPackageFullAccess'
       Policies:
         - PolicyDocument:
             Statement:


### PR DESCRIPTION
# Description

https://github.com/cloudnativedaysjp/dreamkast/issues/989 で進めている新しい録画アーキテクチャでは[lAWS MediaPackage](https://aws.amazon.com/jp/mediapackage/)を使うようになる。しかし、NodeInstanceRoleがMediaPackageを扱う権限を持っていないので許可する。

```
dreamkast-774db758dd-qpdkr dreamkast E, [2022-01-16T04:00:17.879864 #13] ERROR -- : [ActiveJob] [CreateMediaPackageJob] [f051b191-ccf6-4b5c-876d-35c2749b0fca] User: arn:aws:sts::607167088920:assumed-role/dreamkast-dev-eks-nodes-bottleroc-NodeInstanceRole-5Q272N37VA19/i-0d58afeeafdf8a311 is not authorized to perform: mediapackage:TagResource on resource: arn:aws:mediapackage:us-east-1:607167088920:channels/*
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
