### PR TITLE
medialiveからmediapackageを扱うにあたり、ssmのパラメータストアにアクセスする必要があるので許可する

### DIFF
--- a/cfn/eks-nodes-bottlerocket.yaml
+++ b/cfn/eks-nodes-bottlerocket.yaml
@@ -101,6 +101,14 @@ Resources:
             Statement:
               - Effect: "Allow"
                 Action:
+                  - "ssm:PutParameter"
+                  - "ssm:DeleteParameter"
+                Resource: "arn:aws:ssm:region:account-id:parameter/medialive/*"
+          PolicyName: "ssm-parameter-create-and-delete"
+        - PolicyDocument:
+            Statement:
+              - Effect: "Allow"
+                Action:
                   - "secretsmanager:GetResourcePolicy"
                   - "secretsmanager:GetSecretValue"
                   - "secretsmanager:DescribeSecret"


### PR DESCRIPTION
# Description


https://github.com/cloudnativedaysjp/dreamkast/issues/989 で進めている新しい録画アーキテクチャでは[lAWS MediaPackage](https://aws.amazon.com/jp/mediapackage/)を使うようになる。しかし、MediaLiveからMediaPackageを利用する際にSSMのパラメータストアを使わなければならないが、権限がなかった。PutParameterとDeleteParameterがあればよいので許可する。

```
dreamkast-774db758dd-qpdkr dreamkast E, [2022-01-16T04:00:17.879864 #13] ERROR -- : [ActiveJob] [CreateMediaPackageJob] [f051b191-ccf6-4b5c-876d-35c2749b0fca] User: arn:aws:sts::607167088920:assumed-role/dreamkast-dev-eks-nodes-bottleroc-NodeInstanceRole-5Q272N37VA19/i-0d58afeeafdf8a311 is not authorized to perform: mediapackage:TagResource on resource: arn:aws:mediapackage:us-east-1:607167088920:channels/*
```


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
