### PR TITLE
Resourceでregionとaccount idを指定する必要があった

### DIFF
--- a/cfn/eks-nodes-bottlerocket.yaml
+++ b/cfn/eks-nodes-bottlerocket.yaml
@@ -103,7 +103,7 @@ Resources:
                 Action:
                   - "ssm:PutParameter"
                   - "ssm:DeleteParameter"
-                Resource: "arn:aws:ssm:region:account-id:parameter/medialive/*"
+                Resource: "arn:aws:ssm:us-east-1:${AWS::AccountId}:parameter/medialive/*"
           PolicyName: "ssm-parameter-create-and-delete"
         - PolicyDocument:
             Statement:


### PR DESCRIPTION
# Description

https://github.com/cloudnativedaysjp/dreamkast/issues/989 で進めている新しい録画アーキテクチャでは[lAWS MediaPackage](https://aws.amazon.com/jp/mediapackage/)を使うようになる。https://github.com/cloudnativedaysjp/dreamkast-infra/pull/1367 でPutParameterとDeleteParameterを扱うポリシーを追加したのだが、Resourceの指定方法が間違っていたので修正する。

```
dreamkast-774db758dd-qpdkr dreamkast E, [2022-01-18T09:57:36.510645 #13] ERROR -- : [ActiveJob] [CreateMediaLiveJob] [9d6575b7-cae7-4d53-96c0-76b3d9d23ede] User: arn:aws:sts::607167088920:assumed-role/dreamkast-dev-eks-nodes-bottleroc-NodeInstanceRole-5Q272N37VA19/i-0d58afeeafdf8a311 is not authorized to perform: ssm:PutParameter on resource: arn:aws:ssm:us-east-1:607167088920:parameter/medialive/review_app_1096_cndt2021_trackB because no identity-based policy allows the ssm:PutParameter action
```



## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
