### PR TITLE
fix patchesStrategicMerge

### DIFF
--- a/manifests/infra/mysql-o11y/overlays/development/cronjob.yaml
+++ b/manifests/infra/mysql-o11y/overlays/development/cronjob.yaml
@@ -10,6 +10,8 @@ spec:
         spec:
           containers:
           - name: mysql
+            image: mysql:8.0
+            args: ["mysqldump --single-transaction --quick --set-charset -u $RDS_USER -p $RDS_PASSWORD -h $RDS_HOST dreamkast conference_days conferences proposal_item_configs proposal_items proposals talk_categories talk_difficulties talk_times talks talks_speakers tracks stats_of_registrants viewer_counts chat_messages > $HOME/rds.dump; mysql -u $MYSQL_USER -p $MYSQL_PASSWORD  -h $MYSQL_HOST dreamkast < $HOME/rds.dump"]
             env:
             - name: RDS_HOST
               value: dreamkast-dev-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com


### PR DESCRIPTION
# Description

ERROR: `CronJob.batch "mysql-o11y" is invalid: spec.jobTemplate.spec.template.spec.containers[0].image: Required value`

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->


```
apiVersion: batch/v1
kind: CronJob
metadata:
  name: mysql-o11y
  namespace: monitoring
spec:
  jobTemplate:
    spec:
      template:
        spec:
          containers:
          - args:
            - mysqldump --single-transaction --quick --set-charset -u $RDS_USER -p
              $RDS_PASSWORD -h $RDS_HOST dreamkast conference_days conferences proposal_item_configs
              proposal_items proposals talk_categories talk_difficulties talk_times
              talks talks_speakers tracks stats_of_registrants viewer_counts chat_messages
              > $HOME/rds.dump; mysql -u $MYSQL_USER -p $MYSQL_PASSWORD  -h $MYSQL_HOST
              dreamkast < $HOME/rds.dump
            env:
            - name: RDS_HOST
              value: dreamkast-dev-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com
            - name: RDS_PASSWORD
              valueFrom:
                secretKeyRef:
                  key: password
                  name: rds-secret
            - name: RDS_USER
              valueFrom:
                secretKeyRef:
                  key: username
                  name: rds-secret
            - name: MYSQL_PASSWORD
              valueFrom:
                secretKeyRef:
                  key: MYSQL_PASSWORD
                  name: mysql-secret
            - name: MYSQL_USER
              valueFrom:
                secretKeyRef:
                  key: MYSQL_USER
                  name: mysql-secret
            - name: MYSQL_HOST
              value: mysql-o11y
            image: mysql:8.0
            name: mysql
          restartPolicy: OnFailure
  schedule: '*/1 * * * *'
```

