### PR TITLE
Remove uneeded namespace at base level

### DIFF
--- a/manifests/infra/mysql-o11y/base/cronjob.yaml
+++ b/manifests/infra/mysql-o11y/base/cronjob.yaml
@@ -2,7 +2,6 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: mysql-o11y
-  namespace: monitoring
 spec:
   schedule: "*/1 * * * *"
   jobTemplate:

--- a/manifests/infra/mysql-o11y/base/deployment.yaml
+++ b/manifests/infra/mysql-o11y/base/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mysql-o11y
-  namespace: monitoring
   labels:
     app: mysql-o11y
 spec:

--- a/manifests/infra/mysql-o11y/base/kustomization.yaml
+++ b/manifests/infra/mysql-o11y/base/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: monitoring
 resources:
 - cronjob.yaml
 - deployment.yaml

--- a/manifests/infra/mysql-o11y/base/pv.yaml
+++ b/manifests/infra/mysql-o11y/base/pv.yaml
@@ -2,7 +2,6 @@ kind: PersistentVolume
 apiVersion: v1
 metadata:
   name: mysql-pv-volume 
-  namespace: monitoring
   labels:
     type: local
 spec:

--- a/manifests/infra/mysql-o11y/base/pvc.yaml
+++ b/manifests/infra/mysql-o11y/base/pvc.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: mysql-pv-claim
-  namespace: monitoring
 spec:
   storageClassName: manual 
   accessModes:

--- a/manifests/infra/mysql-o11y/base/service.yaml
+++ b/manifests/infra/mysql-o11y/base/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: mysql-o11y
-  namespace: monitoring
   labels:
     app: mysql-o11y
 spec:

--- a/manifests/infra/mysql-o11y/overlays/development/cronjob.yaml
+++ b/manifests/infra/mysql-o11y/overlays/development/cronjob.yaml
@@ -2,7 +2,6 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: mysql-o11y
-  namespace: monitoring
 spec:
   jobTemplate:
     spec:

--- a/manifests/infra/mysql-o11y/overlays/development/secret.yaml
+++ b/manifests/infra/mysql-o11y/overlays/development/secret.yaml
@@ -2,7 +2,6 @@ apiVersion: 'kubernetes-client.io/v1'
 kind: ExternalSecret
 metadata:
   name: rds-secret
-  namespace: monitoring
 spec:
   backendType: secretsManager
   data:
@@ -17,7 +16,6 @@ apiVersion: 'kubernetes-client.io/v1'
 kind: ExternalSecret
 metadata:
   name: mysql-secret
-  namespace: monitoring
 spec:
   backendType: secretsManager
   data:

--- a/manifests/infra/mysql-o11y/overlays/production/cronjob.yaml
+++ b/manifests/infra/mysql-o11y/overlays/production/cronjob.yaml
@@ -2,7 +2,6 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: mysql-o11y
-  namespace: monitoring
 spec:
   jobTemplate:
     spec:

--- a/manifests/infra/mysql-o11y/overlays/production/secret.yaml
+++ b/manifests/infra/mysql-o11y/overlays/production/secret.yaml
@@ -2,7 +2,6 @@ apiVersion: 'kubernetes-client.io/v1'
 kind: ExternalSecret
 metadata:
   name: rds-secret
-  namespace: monitoring
 spec:
   backendType: secretsManager
   data:
@@ -17,7 +16,6 @@ apiVersion: 'kubernetes-client.io/v1'
 kind: ExternalSecret
 metadata:
   name: mysql-secret
-  namespace: monitoring
 spec:
   backendType: secretsManager
   data:


### PR DESCRIPTION
# Description

Baseレベルのnamespace指定は不要です。
Baseレベルでnamespaceを指定されると、手元の環境でNamespaceの変更が難しくなりますので、直させてください。

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`kustomize build` してもnamespaceがちゃんと付与されることを確認しています。
