### PR TITLE
update metrics server to 0.5.2

### DIFF
--- a/manifests/argocd-apps/prd/metrics-server.yaml
+++ b/manifests/argocd-apps/prd/metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   source:
     path: manifests/release
     repoURL: https://github.com/kubernetes-sigs/metrics-server.git
-    targetRevision: v0.4.2
+    targetRevision: v0.5.2
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
# Description

Update metrics-server to 0.5.2

## Type of change

https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.5.0 basically contains performance and reliability improvements, the base version is now 1.21 that matches the EKS cluster veresion.

- [ ] Document update or simple typo fix
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
