### PR TITLE
add cronjob for rake task polling-harvest-job-and-update-video

### DIFF
--- a/manifests/app/dreamkast/overlays/production/main/polling-harvest-job-and-update-video.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/polling-harvest-job-and-update-video.yaml
@@ -1,0 +1,83 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: polling-harvest-job-and-update-video
+spec:
+  schedule: "*/3 * * * *"
+  startingDeadlineSeconds: 120
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: dreamkast
+              image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ecs:main
+              command:
+                - /bin/sh
+                - -c
+                - bundle exec rake util:polling_harvest_job_and_update_video
+              env:
+                - name: RAILS_ENV
+                  value: "production"
+                - name: MYSQL_HOST
+                  value: "dreamkast-prd-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+                - name: MYSQL_DATABASE
+                  value: "dreamkast"
+                - name: REDIS_URL
+                  value: "redis://dreamkast-redis:6379"
+                - name: SENTRY_DSN
+                  value: "https://443f0535beb64cd8b2e995d001e0903b@o414348.ingest.sentry.io/5350644"
+                - name: S3_BUCKET
+                  value: "dreamkast-prd-bucket"
+                - name: S3_REGION
+                  value: ap-northeast-1
+                - name: AWS_REGION
+                  value: ap-northeast-1
+                - name: SQS_MAIL_QUEUE_URL
+                  value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-prdMailQueue.fifo"
+                - name: SLACK_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: SLACK_WEBHOOK_URL_FOR_HARVEST_JOB_NOTIFICATION
+                - name: SLACK_CHANNEL
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: SLACK_CHANNEL_FOR_HARVEST_JOB_NOTIFICATION
+                - name: DREAMKAST_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: RAILS_MASTER_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: rails-app-secret
+                      key: rails-app-secret
+                - name: MYSQL_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: db-secret
+                      key: username
+                - name: MYSQL_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: db-secret
+                      key: password
+                - name: AUTH0_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: AUTH0_CLIENT_ID
+                - name: AUTH0_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: AUTH0_CLIENT_SECRET
+                - name: AUTH0_DOMAIN
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: AUTH0_DOMAIN
+          restartPolicy: OnFailure

--- a/manifests/app/dreamkast/overlays/staging/main/polling-harvest-job-and-update-video.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/polling-harvest-job-and-update-video.yaml
@@ -1,0 +1,83 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: polling-harvest-job-and-update-video
+spec:
+  schedule: "*/3 * * * *"
+  startingDeadlineSeconds: 120
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: dreamkast
+              image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ecs:main
+              command:
+                - /bin/sh
+                - -c
+                - bundle exec rake util:polling_harvest_job_and_update_video
+              env:
+                - name: RAILS_ENV
+                  value: "production"
+                - name: MYSQL_HOST
+                  value: "dreamkast-dev-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+                - name: MYSQL_DATABASE
+                  value: "dreamkast"
+                - name: REDIS_URL
+                  value: "redis://dreamkast-redis:6379"
+                - name: SENTRY_DSN
+                  value: "https://82e52bc9814f478a917a9f4b2a190202@o414348.ingest.sentry.io/5303654"
+                - name: S3_BUCKET
+                  value: "dreamkast-stg-bucket"
+                - name: S3_REGION
+                  value: ap-northeast-1
+                - name: AWS_REGION
+                  value: ap-northeast-1
+                - name: SQS_MAIL_QUEUE_URL
+                  value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-stgMailQueue.fifo"
+                - name: SLACK_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: SLACK_WEBHOOK_URL_FOR_HARVEST_JOB_NOTIFICATION
+                - name: SLACK_CHANNEL
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: SLACK_CHANNEL_FOR_HARVEST_JOB_NOTIFICATION
+                - name: DREAMKAST_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: RAILS_MASTER_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: rails-app-secret
+                      key: rails-app-secret
+                - name: MYSQL_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: db-secret
+                      key: username
+                - name: MYSQL_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: db-secret
+                      key: password
+                - name: AUTH0_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: AUTH0_CLIENT_ID
+                - name: AUTH0_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: AUTH0_CLIENT_SECRET
+                - name: AUTH0_DOMAIN
+                  valueFrom:
+                    secretKeyRef:
+                      name: dreamkast-secret
+                      key: AUTH0_DOMAIN
+          restartPolicy: OnFailure

--- a/manifests/reviewapps/dreamkast.yaml
+++ b/manifests/reviewapps/dreamkast.yaml
@@ -650,4 +650,81 @@ spec:
                             name: dreamkast-secret
                             key: REVIEW_APP
                 restartPolicy: OnFailure
+    polling-harvest-job-and-update-video.yaml: |
+      apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: polling-harvest-job-and-update-video
+      spec:
+        schedule: "*/3 * * * *"
+        startingDeadlineSeconds: 120
+        concurrencyPolicy: Forbid
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: dreamkast
+                    image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ecs:main
+                    command:
+                      - /bin/sh
+                      - -c
+                      - bundle exec rake util:polling_harvest_job_and_update_video
+                    env:
+                      - name: RAILS_ENV
+                        value: "production"
+                      - name: MYSQL_HOST
+                        value: "dreamkast-mysql"
+                      - name: REDIS_URL
+                        value: "redis://dreamkast-redis:6379"
+                      - name: SENTRY_DSN
+                        value: "https://443f0535beb64cd8b2e995d001e0903b@o414348.ingest.sentry.io/5350644"
+                      - name: S3_BUCKET
+                        value: "dreamkast-test-bucket"
+                      - name: S3_REGION
+                        value: ap-northeast-1
+                      - name: SQS_FIFO_QUEUE_URL
+                        value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/devFifoQueue.fifo"
+                      - name: SLACK_WEBHOOK_URL
+                        valueFrom:
+                          secretKeyRef:
+                            name: dreamkast-secret
+                            key: SLACK_WEBHOOK_URL_FOR_HARVEST_JOB_NOTIFICATION
+                      - name: SLACK_CHANNEL
+                        valueFrom:
+                          secretKeyRef:
+                            name: dreamkast-secret
+                            key: SLACK_CHANNEL_FOR_HARVEST_JOB_NOTIFICATION
+                      - name: AWS_REGION
+                        value: ap-northeast-1
+                      - name: DREAMKAST_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: RAILS_MASTER_KEY
+                        valueFrom:
+                          secretKeyRef:
+                            name: rails-app-secret
+                            key: rails-app-secret
+                      - name: AUTH0_CLIENT_ID
+                        valueFrom:
+                          secretKeyRef:
+                            name: dreamkast-secret
+                            key: AUTH0_CLIENT_ID
+                      - name: AUTH0_CLIENT_SECRET
+                        valueFrom:
+                          secretKeyRef:
+                            name: dreamkast-secret
+                            key: AUTH0_CLIENT_SECRET
+                      - name: AUTH0_DOMAIN
+                        valueFrom:
+                          secretKeyRef:
+                            name: dreamkast-secret
+                            key: AUTH0_DOMAIN
+                      - name: REVIEW_APP
+                        valueFrom:
+                          secretKeyRef:
+                            name: dreamkast-secret
+                            key: REVIEW_APP
+                restartPolicy: OnFailure
   candidate: *manifests


### PR DESCRIPTION
# Description

This PR adds cronjob to run `rake util:polling_harvest_job_and_update_video` command that is added by https://github.com/cloudnativedaysjp/dreamkast/pull/1100 . This Cronjob polling Harvest Job of AWS Media Package.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

https://github.com/cloudnativedaysjp/dreamkast/issues/989

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
