### PR TITLE
Remove stats_of_registrants viewer_counts table

### DIFF
--- a/manifests/infra/mysql-o11y/overlays/development/cronjob.yaml
+++ b/manifests/infra/mysql-o11y/overlays/development/cronjob.yaml
@@ -22,7 +22,7 @@ spec:
               -u $RDS_USER -p"$RDS_PASSWORD" -h $RDS_HOST dreamkast \
               conference_days conferences proposal_item_configs proposal_items \
               proposals talk_categories talk_difficulties talk_times talks talks_speakers \
-              tracks stats_of_registrants viewer_counts \
+              tracks \
               > $HOME/rds.dump; \
               mysql -u $MYSQL_USER -p"$MYSQL_PASSWORD" -h $MYSQL_HOST dreamkast < $HOME/rds.dump
             env:

--- a/manifests/infra/mysql-o11y/overlays/production/cronjob.yaml
+++ b/manifests/infra/mysql-o11y/overlays/production/cronjob.yaml
@@ -22,7 +22,7 @@ spec:
               -u $RDS_USER -p"$RDS_PASSWORD" -h $RDS_HOST dreamkast \
               conference_days conferences proposal_item_configs proposal_items \
               proposals talk_categories talk_difficulties talk_times talks talks_speakers \
-              tracks stats_of_registrants viewer_counts \
+              tracks \
               > $HOME/rds.dump; \
               mysql -u $MYSQL_USER -p"$MYSQL_PASSWORD" -h $MYSQL_HOST dreamkast < $HOME/rds.dump
             env:

--- a/manifests/infra/telegraf/base/configmap.yaml
+++ b/manifests/infra/telegraf/base/configmap.yaml
@@ -101,9 +101,6 @@ data:
         query="SELECT t.id AS talk_id,p.label,p.params FROM proposal_items p LEFT JOIN talks t ON p.talk_id = t.id  WHERE ( p.label = 'presentation_method' OR p.label = 'assumed_visitor' OR p.label = 'execution_phase' OR p.label = 'whether_it_can_be_published') AND p.conference_id='${CONF_ID}'"
         measurement = "dreamkast_proposal_items"
         tag_columns_include = [ "labels", "params" ]
-      [[inputs.sql.query]]
-        query="SELECT number_of_registrants FROM stats_of_registrants WHERE conference_id='${CONF_ID}'"
-        measurement = "dreamkast"
   
     [[inputs.github]]
       ## prevent rate limit, query per 30min


### PR DESCRIPTION
# Description

stats_of_registrants viewer_countsのテーブルが想定と異なり、履歴も全部保存するため、1000行以上保存するテーブルであった。
このため、当日のダンプがどんどん重くなる可能性がある。

そもそも cloudnativedaysjp/dreamkast#1152 により対応は不要になったと判断

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [x] Maintenance/update components
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`kustomize build ./` による検査

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
