### PR TITLE
change to probe monitoring

### DIFF
--- a/manifests/infra/prometheus/overlays/development/kustomization.yaml
+++ b/manifests/infra/prometheus/overlays/development/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
 - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.52.1/bundle.yaml
 - ../../base
 - service-monitor.yaml
+- probe.yaml
 patchesStrategicMerge:
 - prometheus-crd.yaml

--- a/manifests/infra/prometheus/overlays/development/probe.yaml
+++ b/manifests/infra/prometheus/overlays/development/probe.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: dreamkast-metrics
+  namespace: monitoring
+spec:
+  interval: 3m
+  targets:
+    staticConfig:
+      static:
+      - https://staging.dev.cloudnativedays.jp/metrics

--- a/manifests/infra/prometheus/overlays/development/service-monitor.yaml
+++ b/manifests/infra/prometheus/overlays/development/service-monitor.yaml
@@ -13,21 +13,3 @@ spec:
   selector:
     matchLabels:
       prometheus: k8s
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: dreamkast-metrics
-  namespace: monitoring
-spec:
-  endpoints:
-  - path: /metrics
-    port: http-port
-    interval: "3m"
-  namespaceSelector:
-    matchNames:
-    - dreamkast-staging
-  selector:
-    matchLabels:
-      app: dreamkast
-      tier: dreamkast


### PR DESCRIPTION
# Description

ServiceMonitorだと、Podがスケールするたびに重複してしまうため、staticConfigに変更

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`kubectl apply -f probes.yaml --dry-run=client -o yaml` および `kubectl apply -f probe.yaml --dry-run=server -o yaml`でYamlが正しいことを確認
`kustomize build ./` でエラーにならないこと確認

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
