### PR TITLE
mainブランチのダッシュボードjsonを参照するよう変更

### DIFF
--- a/manifests/argocd-apps/dev/grafana.yaml
+++ b/manifests/argocd-apps/dev/grafana.yaml
@@ -69,7 +69,7 @@ spec:
           public:
             o11y2022 proposals:
               datasource: Prometheus
-              url: https://raw.githubusercontent.com/cloudnativedaysjp/dreamkast-infra/763374fa6c81e478a568a20d745483244c5fdc89/dashboards/o11y2022-cfp.json
+              url: https://raw.githubusercontent.com/cloudnativedaysjp/dreamkast-infra/main/dashboards/o11y2022-cfp.json
           private:
             Amazon RDS:
               gnetId: 11264
@@ -90,7 +90,7 @@ spec:
               revision: 1
             o11y2022 main:
               datasource: Prometheus
-              url: https://raw.githubusercontent.com/cloudnativedaysjp/dreamkast-infra/cf425608c0d2976551013c566dbc0a998919bc98/dashboards/o11y2022-main.json  
+              url: https://raw.githubusercontent.com/cloudnativedaysjp/dreamkast-infra/main/dashboards/o11y2022-main.json
             Persistent Volume Usage:
               datasource: Prometheus
               gnetId: 13646
@@ -101,9 +101,9 @@ spec:
               revision: 16
             Contour-HTTProxy:
               datasource: Prometheus
-              url: https://raw.githubusercontent.com/cloudnativedaysjp/dreamkast-infra/48af40799e166126799fc86fa34be9db879629d2/dashboards/Contour-HTTProxy.json
+              url: https://raw.githubusercontent.com/cloudnativedaysjp/dreamkast-infra/main/dashboards/Contour-HTTProxy.json
             Kubernetes-Pod:
-              url: https://raw.githubusercontent.com/cloudnativedaysjp/dreamkast-infra/fd5ec445ad41b900765e1bd69ab7f59d7060aa4c/dashboards/Kubernetes-Pod.json
+              url: https://raw.githubusercontent.com/cloudnativedaysjp/dreamkast-infra/main/dashboards/Kubernetes-Pod.json
         envFromSecret: grafana-secret
         grafana.ini:
           server:


### PR DESCRIPTION
# Description

Grafanaダッシュボードの定義jsonを指定する際に、特定のコミットハッシュ付きでjsonファイルを指定していたが、これをmainブランチのjsonファイルを指定するよう変更する。

jsonファイルの更新と参照の更新の2ステップを同じタイミングで実施するケースが多く、jsonファイルの参照更新漏れを防止することが狙い。
本番環境側は安全に倒し、特定ハッシュを指定する運用を継続する。

Related to #1536

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
