### PR TITLE
remove elasticsearch from jaeger

### DIFF
--- a/manifests/argocd-apps/dev/jaeger.yaml
+++ b/manifests/argocd-apps/dev/jaeger.yaml
@@ -19,17 +19,16 @@ spec:
       values: |
         provisionDataStore:
           cassandra: false
-          elasticsearch: true
-          kafka: false
+        allInOne:
+          enabled: true
         storage:
-          type: elasticsearch
-        elasticsearch:
-          replicas: 1
-          extraEnvs:
-            - name: discovery.type
-              value: single-node
-            - name: cluster.initial_master_nodes
-              value: null
+          type: none
+        agent:
+          enabled: false
+        collector:
+          enabled: false
+        query:
+          enabled: false
   syncPolicy:
     automated:
       prune: true

--- a/manifests/argocd-apps/prd/jaeger.yaml
+++ b/manifests/argocd-apps/prd/jaeger.yaml
@@ -19,17 +19,16 @@ spec:
       values: |
         provisionDataStore:
           cassandra: false
-          elasticsearch: true
-          kafka: false
+        allInOne:
+          enabled: true
         storage:
-          type: elasticsearch
-        elasticsearch:
-          replicas: 1
-          extraEnvs:
-            - name: discovery.type
-              value: single-node
-            - name: cluster.initial_master_nodes
-              value: null
+          type: none
+        agent:
+          enabled: false
+        collector:
+          enabled: false
+        query:
+          enabled: false
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
# Description

Jaegerがまともに動いてないので（おもにElasticsearchのせい）、All in Oneでインメモリストアする構成にする。永続性はまあそんなに重要じゃないと思っているが必要であれば検討する形にする。どのみち動いてないので本番もいっしょにあげちゃう

ref. https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger#all-in-one-in-memory-configuration

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
