### PR TITLE
change target namespace of kube-state-metrics: kube-system > monitoring

### DIFF
--- a/manifests/infra/prometheus/overlays/development/kube-state-metrics/kustomization.yaml
+++ b/manifests/infra/prometheus/overlays/development/kube-state-metrics/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: monitoring
 resources:
 - https://raw.githubusercontent.com/kubernetes/kube-state-metrics/v2.4.2/examples/standard/cluster-role-binding.yaml
 - https://raw.githubusercontent.com/kubernetes/kube-state-metrics/v2.4.2/examples/standard/cluster-role.yaml


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1619 

kube-state-metrics が monitoring Namespace に居なかったので、Prometheus のスクレイピング対象におらず、アラートも効いていませんでした。

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
