### PR TITLE
fix alert that reviewapp-operator Pod become crash

### DIFF
--- a/manifests/infra/prometheus/overlays/development/kube-state-metrics/alert-rules.yaml
+++ b/manifests/infra/prometheus/overlays/development/kube-state-metrics/alert-rules.yaml
@@ -9,8 +9,8 @@ spec:
   - name: reviewapp_operator
     rules:
     - alert: ReviewAppIsDown
-      expr: irate(kube_pod_container_status_restarts_total{exported_pod=~"^reviewapp-operator-controller-manager-.*$"}[1m]) >= 3
-      for: 1m
+      expr: rate(kube_pod_container_status_restarts_total{exported_pod=~"^reviewapp-operator-controller-manager-.*$"}[6m]) > 0
+      for: 12m # pod's crashLoopBackOff was occurred for 6 minutes (12m-6m)
       labels:
         severity: critical
       annotations:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

* Fixes #1641
    * in current, alert rule is not matched at all :cry: 🙇 
    * this PR make alert-rule become sensitive. if it's so noisy, I will improve it.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [x] Maintenance/update components
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
