### PR TITLE
Revert "Add Helm options to Falco chart"

### DIFF
--- a/manifests/argocd-apps/dev/falco.yaml
+++ b/manifests/argocd-apps/dev/falco.yaml
@@ -9,17 +9,7 @@ spec:
     targetRevision: 1.19.4
     helm:
       values: |
-        docker:
-          enabled: false
-        crio:
-          enabled: false
-        timezone: Asia/Tokyo
         ebpf:
-          enabled: true
-        leastPrivileged:
-          # Constrain Falco with capabilities instead of running a privileged container.
-          # This option is only supported with the eBPF driver and a kernel >= 5.8.
-          # Ensure the eBPF driver is enabled (i.e., setting the `ebpf.enabled` option to true).
           enabled: true
         falco:
           grpc:


### PR DESCRIPTION
Reverts cloudnativedaysjp/dreamkast-infra#1709

Bottlerocket OS上ではeBPF moduleのDLに失敗して最小権限モードで動かなかった