### PR TITLE
NO-ISSUE: on ArgoCD Plugin: fix bug occurred when a space contains in input

### DIFF
--- a/manifests/argocd/overlays/dev/argocd-cm.yaml
+++ b/manifests/argocd/overlays/dev/argocd-cm.yaml
@@ -27,8 +27,9 @@ data:
       init:
         command: ["bash", "-euxc"]
         args:
-        - export IFS=",";
-          for image in ${ARGOCD_ENV_IMAGES}; do
+        - images=$(echo ${ARGOCD_ENV_IMAGES} | sed -e 's/ //g');
+          export IFS=",";
+          for image in $images; do
             kustomize edit set image $image;
           done;
           kustomize edit set namespace $ARGOCD_ENV_NAMESPACE;


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

On the known issue, `kustomize-with-replacements` ArgoCD Plugin does not work well when we write applicationset.yml for ReviewApp as below (unrelated lines are snipped).

```
apiVersion: argoproj.io/v1alpha1
kind: ApplicationSet
metadata:
  name: example
spec:
  template:
    spec:
      source:
        plugin:
          name: kustomize-with-replacements
          env:
            - name: IMAGES
              value: >-
                dreamkast-ecs=public.ecr.aws/q5p7z1m4/dreamkast-ecs:{{head_sha}},
                dreamkast-ui=public.ecr.aws/q5p7z1m4/dreamkast-ui:main
```

In the last 3 lines, I use `>-` literal, which replaces "new line (`\n`)"  with "space (` `)".
But I was misunderstood as `>-` replaces "new line (`\n`)"  with "no character (``)". So `kustomize-with-replacements` Argo CD Plugin does not work well.

I fixed this issue in this PR.

---

* No Issue
* reference on Slack: https://cloudnativedays.slack.com/archives/C015CN1PQ06/p1661065354424879

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.
