### PR TITLE
update targets on chatbot

### DIFF
--- a/manifests/app/chatbot/configmap.yaml
+++ b/manifests/app/chatbot/configmap.yaml
@@ -20,7 +20,5 @@ data:
         baseBranch: main
       - url: https://github.com/cloudnativedaysjp/website
         baseBranch: main
-      - url: https://github.com/cloudopsdays/dreamkast_codt2022
-        baseBranch: main
-      - url: https://github.com/cloudopsdays/dreamkast-ui_codt2022
+      - url: https://github.com/cloudnativedaysjp/chatbot
         baseBranch: main


### PR DESCRIPTION
remove the following targets because CODT2022 has been finished.

* https://github.com/cloudopsdays/dreamkast_codt2022
* https://github.com/cloudopsdays/dreamkast-ui_codt2022

add the following target 

* https://github.com/cloudnativedaysjp/chatbot/