### PR TITLE
Add Github Dashboard to prod

### DIFF
--- a/manifests/argocd-apps/prd/grafana.yaml
+++ b/manifests/argocd-apps/prd/grafana.yaml
@@ -115,6 +115,9 @@ spec:
               url: https://raw.githubusercontent.com/cloudnativedaysjp/dreamkast-infra/01d27ac125fc2edcc6db9f8ab6f0e62149cf9952/dashboards/Kubernetes-Pod.json
             Falco:
               url: https://raw.githubusercontent.com/cloudnativedaysjp/dreamkast-infra/2ac295664c31e3096a142b237e95881436c4e2d4/dashboards/falco-dashboard.json
+            Github:
+              datasource: Prometheus
+              url: https://raw.githubusercontent.com/cloudnativedaysjp/dreamkast-infra/f1706b5c796f37259cf6b3020b23203a3fa15e7e/dashboards/github.json
         envFromSecret: grafana-secret
         grafana.ini:
           server:


### PR DESCRIPTION
# Description

GrafanaのGithub dashboardが、devだとデータ保持期間が短すぎてIssue数の推移が見れないので、prodにdeployさせてください。
privateに配置して非公開なので、prodにおいて問題ない認識です（そもそもIssue数は公開情報なので、公開しても良いかもですが）

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
