### PR TITLE
Use db:seed instead of seed_fu

### DIFF
--- a/manifests/app/dreamkast/overlays/development/template-dk/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/development/template-dk/deployment-dreamkast.yaml
@@ -28,7 +28,7 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - bundle exec rails db:migrate;
-          bundle exec rails db:seed_fu;
+          bundle exec rails db:seed;
         env:
         - name: RAILS_ENV
           value: "production"

--- a/manifests/app/dreamkast/overlays/development/template-ui/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/development/template-ui/deployment-dreamkast.yaml
@@ -28,7 +28,7 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - bundle exec rails db:migrate;
-          bundle exec rails db:seed_fu;
+          bundle exec rails db:seed;
         env:
         - name: RAILS_ENV
           value: "production"

--- a/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast.yaml
@@ -29,7 +29,7 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - bundle exec rails db:migrate;
-          bundle exec rails db:seed_fu;
+          bundle exec rails db:seed;
         env:
         - name: RAILS_ENV
           value: "production"

--- a/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast.yaml
@@ -29,7 +29,7 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - bundle exec rails db:migrate;
-          bundle exec rails db:seed_fu;
+          bundle exec rails db:seed;
         env:
         - name: RAILS_ENV
           value: "production"


### PR DESCRIPTION
# Description

`db:seed_fu` getting failed because seed_fu doesn't read a helper file. To resolve this, I changed init command to use `db:seed`


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
