### PR TITLE
Install KEDA & Install to dreamkast-staging

### DIFF
--- a/manifests/app/dreamkast/overlays/staging/main/hpa.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/hpa.yaml
@@ -1,5 +1,6 @@
-apiVersion: autoscaling/v2beta2
-kind: HorizontalPodAutoscaler
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
 metadata:
   name: dreamkast
 spec:
@@ -7,19 +8,24 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: dreamkast
-  minReplicas: 1
-  maxReplicas: 1
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 50
-  behavior:
-    scaleDown:
-      stabilizationWindowSeconds: 2400
-      policies:
-      - type: Pods
-        value: 1
-        periodSeconds: 60
+  pollingInterval:  30
+  minReplicaCount:  1
+  maxReplicaCount:  3
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 2400
+          policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 60
+  triggers:
+  - type: cpu
+    metadata:
+      type: Utilization
+      value: "50"
+  - type: external
+    metadata:
+      scalerAddress: dreamkast-external-scaler.keda.svc:6000
+      minReplicas: "2"

--- a/manifests/argocd-apps/dev/keda.yaml
+++ b/manifests/argocd-apps/dev/keda.yaml
@@ -15,10 +15,6 @@ spec:
     chart: keda
     repoURL: https://kedacore.github.io/charts
     targetRevision: 2.8.1
-    helm:
-      parameters:
-      - name: loki.persistence.enabled
-        value: "true"
   syncPolicy:
     automated:
       prune: true

--- a/manifests/argocd-apps/dev/keda.yaml
+++ b/manifests/argocd-apps/dev/keda.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keda
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion
+spec:
+  destination:
+    namespace: keda
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    chart: keda
+    repoURL: https://kedacore.github.io/charts
+    targetRevision: 2.8.1
+    helm:
+      parameters:
+      - name: loki.persistence.enabled
+        value: "true"
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keda-external-scalers
+  namespace: argocd
+spec:
+  destination:
+    namespace: keda
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
+    path: manifests/infra/keda-external-sclaers/overlays/development
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/manifests/infra/keda-external-scalers/overlays/development/dreamkast-external-scaler.yaml
+++ b/manifests/infra/keda-external-scalers/overlays/development/dreamkast-external-scaler.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dreamkast-external-scaler
+  name: dreamkast-external-scaler
+spec:
+  selector:
+    matchLabels:
+      app: dreamkast-external-scaler
+  template:
+    metadata:
+      labels:
+        app: dreamkast-external-scaler
+    spec:
+      containers:
+      - name: dreamkast-external-scaler
+        image: public.ecr.aws/f5j9d0q5/dreamkast-external-scaler
+        imagePullPolicy: Always
+        env:
+        - name: DK_ENDPOINT_URL
+          value: "https://staging.dev.cloudnativedays.jp/api"
+        livenessProbe:
+          tcpSocket:
+            port: 6000
+          failureThreshold: 5
+          periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: 6000
+          failureThreshold: 5
+          periodSeconds: 10
+        startupProbe:
+          tcpSocket:
+            port: 6000
+          failureThreshold: 30
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dreamkast-external-sclaer
+spec:
+  ports:
+    - port: 6000
+      targetPort: 6000
+      protocol: TCP
+  selector:
+    app: dreamkast-external-scaler

--- a/manifests/infra/keda-external-scalers/overlays/development/kustomization.yaml
+++ b/manifests/infra/keda-external-scalers/overlays/development/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: keda
+resources:
+- ./dreamkast-external-scaler.yaml
+images:
+- name: public.ecr.aws/f5j9d0q5/dreamkast-external-scaler
+  newTag: main
+

--- a/manifests/infra/keda-external-scalers/overlays/development/kustomization.yaml
+++ b/manifests/infra/keda-external-scalers/overlays/development/kustomization.yaml
@@ -5,5 +5,4 @@ resources:
 - ./dreamkast-external-scaler.yaml
 images:
 - name: public.ecr.aws/f5j9d0q5/dreamkast-external-scaler
-  newTag: main
-
+  newTag: v1.0.0


### PR DESCRIPTION
# Description

No Issue

* Install [KEDA](https://github.com/kedacore/keda) & [dreamkast-external-scaler](https://github.com/cloudnativedaysjp/dreamkast-external-scaler)
* apply KEDA ScaledObject to dreamkast-staging
    * KEDA ScaledObject:
        * threshold 1: CPU 50% (as usual)
        * threshold 2: minReplicas is adjusted to ScaledObject.spec.triggers.metadata.minReplicas if today is conference date
    * remove HPA

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
