### PR TITLE
Replace cndt2022 hardcoded with cicd2023

### DIFF
--- a/manifests/app/dreamkast/base/deployment.yaml
+++ b/manifests/app/dreamkast/base/deployment.yaml
@@ -69,23 +69,23 @@ spec:
         - containerPort: 3001
         env:
         - name: NEXT_PUBLIC_BASE_PATH
-          value: /cndt2022/ui
+          value: /cicd2023/ui
         livenessProbe:
           httpGet:
             port: 3001
-            path: /cndt2022/ui/
+            path: /cicd2023/ui/
           failureThreshold: 5
           periodSeconds: 5
         readinessProbe:
           httpGet:
             port: 3001
-            path: /cndt2022/ui/
+            path: /cicd2023/ui/
           failureThreshold: 5
           periodSeconds: 5
         startupProbe:
           httpGet:
             port: 3001
-            path: /cndt2022/ui/
+            path: /cicd2023/ui/
           failureThreshold: 30
           periodSeconds: 10
         resources:

--- a/manifests/app/dreamkast/overlays/development/template-dk/ingress.yaml
+++ b/manifests/app/dreamkast/overlays/development/template-dk/ingress.yaml
@@ -22,7 +22,7 @@ spec:
       - name: dreamkast
         port: 80
     - conditions: #TODO: Need to resolve this hardcoded routing
-      - prefix: /cndt2022/ui
+      - prefix: /cicd2023/ui
       services:
       - name: dreamkast-ui
         port: 3001

--- a/manifests/app/dreamkast/overlays/development/template-ui/deployment-dreamkast-ui.yaml
+++ b/manifests/app/dreamkast/overlays/development/template-ui/deployment-dreamkast-ui.yaml
@@ -47,7 +47,7 @@ spec:
               name: dreamkast-ui-secret
               key: NEXT_PUBLIC_AUTH0_AUDIENCE
         - name: NEXT_PUBLIC_BASE_PATH
-          value: /cndt2022/ui
+          value: /cicd2023/ui
         - name: NEXT_PUBLIC_EVENT_SALT
           valueFrom:
             secretKeyRef:
@@ -57,19 +57,19 @@ spec:
         livenessProbe:
           httpGet:
             port: 3001
-            path: /cndt2022/ui/
+            path: /cicd2023/ui/
           failureThreshold: 5
           periodSeconds: 5
         readinessProbe:
           httpGet:
             port: 3001
-            path: /cndt2022/ui/
+            path: /cicd2023/ui/
           failureThreshold: 5
           periodSeconds: 5
         startupProbe:
           httpGet:
             port: 3001
-            path: /cndt2022/ui/
+            path: /cicd2023/ui/
           failureThreshold: 30
           periodSeconds: 10
         resources:

--- a/manifests/app/dreamkast/overlays/development/template-ui/ingress.yaml
+++ b/manifests/app/dreamkast/overlays/development/template-ui/ingress.yaml
@@ -11,7 +11,7 @@ spec:
       secretName: cert-manager/wildcard-dev-cloudnativedays-jp
   routes:
     - conditions: #TODO: Need to resolve this hardcoded routing
-      - prefix: /cndt2022/ui
+      - prefix: /cicd2023/ui
       services:
       - name: dreamkast-ui
         port: 3001

--- a/manifests/app/dreamkast/overlays/production/main/ingress.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/ingress.yaml
@@ -35,7 +35,7 @@ spec:
       - name: X-Contour-Session-Affinity
         secure: true
     - conditions:
-      - prefix: /cndt2022/ui
+      - prefix: /cicd2023/ui
       services:
       - name: dreamkast-ui
         port: 3001

--- a/manifests/app/dreamkast/overlays/staging/main/ingress.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/ingress.yaml
@@ -31,7 +31,7 @@ spec:
       - name: _session_id
         secure: true
     - conditions:
-      - prefix: /cndt2022/ui
+      - prefix: /cicd2023/ui
       services:
       - name: dreamkast-ui
         port: 3001


### PR DESCRIPTION
CICD2023のプレイベント向けの動作確認をしようと思ったら、マニフェスト側がCNDT2022のまま更新されておらずアクセスできなかったので、修正しました。