### PR TITLE
fix: add NEXT_PUBLIC_DK_URL env var

### DIFF
--- a/manifests/app/dreamkast/overlays/development/template-ui/deployment-dreamkast-ui.yaml
+++ b/manifests/app/dreamkast/overlays/development/template-ui/deployment-dreamkast-ui.yaml
@@ -31,6 +31,8 @@ spec:
         env:
         - name: NEXT_PUBLIC_API_BASE_URL
           value: https://api.dev.cloudnativedays.jp/
+        - name: NEXT_PUBLIC_DK_URL
+          value: https://stating.dev.cloudnativedays.jp
         - name: NEXT_PUBLIC_AUTH0_DOMAIN
           valueFrom:
             secretKeyRef:

--- a/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast-ui.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast-ui.yaml
@@ -10,6 +10,8 @@ spec:
         env:
         - name: NEXT_PUBLIC_API_BASE_URL
           value: https://api.cloudnativedays.jp
+        - name: NEXT_PUBLIC_DK_URL
+          value: https://event.cloudnativedays.jp
         - name: NEXT_PUBLIC_AUTH0_DOMAIN
           valueFrom:
             secretKeyRef:

--- a/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast-ui.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast-ui.yaml
@@ -10,6 +10,8 @@ spec:
         env:
         - name: NEXT_PUBLIC_API_BASE_URL
           value: https://api.stg.cloudnativedays.jp
+        - name: NEXT_PUBLIC_DK_URL
+          value: https://stating.dev.cloudnativedays.jp
         - name: NEXT_PUBLIC_AUTH0_DOMAIN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
このPRとセットの、環境変数追加です。
websocketに限りapi gatewayを経由せず直たたきするために使います

https://github.com/cloudnativedaysjp/dreamkast-ui/pull/397