### PR TITLE
feat: Add dreamkast-weaver in staging

### DIFF
--- a/manifests/app/dreamkast/base/deployment.yaml
+++ b/manifests/app/dreamkast/base/deployment.yaml
@@ -125,13 +125,16 @@ spec:
         tier: dreamkast-weaver
     spec:
       initContainers:
-      - name: initdb
-        image: dreamkast-weaver-initdb
+      - name: dkw-dbmigrate
+        image: dreamkast-weaver
         imagePullPolicy: Always
+        command: ["/dkw","dbmigrate"]
       containers:
-      - image: dreamkast-weaver-serve
+      - image: dreamkast-weaver
         imagePullPolicy: Always
-        name: serve
+        name: dkw-serve
+        command: ["/dkw","serve"]
+        args: ["port=8080"]
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/manifests/app/dreamkast/base/deployment.yaml
+++ b/manifests/app/dreamkast/base/deployment.yaml
@@ -99,3 +99,67 @@ spec:
           preStop:
             exec:
               command: ["/bin/sleep","300"]
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dreamkast
+    tier: dreamkast-weaver
+  name: dreamkast-weaver
+spec:
+  selector:
+    matchLabels:
+      app: dreamkast
+      tier: dreamkast-weaver
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: dreamkast
+        tier: dreamkast-weaver
+    spec:
+      initContainers:
+      - name: initdb
+        image: dreamkast-weaver-initdb
+        imagePullPolicy: Always
+      containers:
+      - image: dreamkast-weaver-serve
+        imagePullPolicy: Always
+        name: serve
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            port: 8080
+            path: /
+          failureThreshold: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            port: 8080
+            path: /
+          failureThreshold: 5
+          periodSeconds: 10
+        startupProbe:
+          httpGet:
+            port: 8080
+            path: /
+          failureThreshold: 30
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sleep","300"]

--- a/manifests/app/dreamkast/base/service.yaml
+++ b/manifests/app/dreamkast/base/service.yaml
@@ -32,3 +32,21 @@ spec:
     app: dreamkast
     tier: dreamkast-ui
   type: NodePort
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: dreamkast
+    tier: dreamkast-weaver
+  name: dreamkast-weaver
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: dreamkast
+    tier: dreamkast-weaver
+  type: ClusterIP

--- a/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast-weaver.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast-weaver.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dreamkast-weaver
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: initdb
+        env:
+        - name: DB_ENDPOINT
+          value: "dreamkast-dev-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+        - name: DB_PORT
+          value: "3306"
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: db-secret
+              key: username
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: db-secret
+              key: password
+      containers:
+      - name: serve
+        env:
+        - name: DB_ENDPOINT
+          value: "dreamkast-dev-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+        - name: DB_PORT
+          value: "3306"
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: db-secret
+              key: username
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: db-secret
+              key: password

--- a/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast-weaver.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast-weaver.yaml
@@ -9,7 +9,7 @@ spec:
       - name: initdb
         env:
         - name: DB_ENDPOINT
-          value: "dreamkast-dev-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+          value: "dk-us-dev-rds.cctlaulyxvbk.us-west-2.rds.amazonaws.com"
         - name: DB_PORT
           value: "3306"
         - name: DB_USER
@@ -26,7 +26,7 @@ spec:
       - name: serve
         env:
         - name: DB_ENDPOINT
-          value: "dreamkast-dev-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+          value: "dk-us-dev-rds.cctlaulyxvbk.us-west-2.rds.amazonaws.com"
         - name: DB_PORT
           value: "3306"
         - name: DB_USER

--- a/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast-weaver.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast-weaver.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       initContainers:
-      - name: initdb
+      - name: dkw-dbmigrate
         env:
         - name: DB_ENDPOINT
           value: "dk-us-dev-rds.cctlaulyxvbk.us-west-2.rds.amazonaws.com"
@@ -23,7 +23,7 @@ spec:
               name: db-secret
               key: password
       containers:
-      - name: serve
+      - name: dkw-serve
         env:
         - name: DB_ENDPOINT
           value: "dk-us-dev-rds.cctlaulyxvbk.us-west-2.rds.amazonaws.com"

--- a/manifests/app/dreamkast/overlays/staging/main/ingress.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/ingress.yaml
@@ -47,3 +47,26 @@ spec:
       - name: _session_id
         secure: true
 
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: dreamkast-weaver
+  labels:
+    app: dreamkast
+    tier: dreamkast-weaver
+spec:
+  virtualhost:
+    # TODO: replace api.dev.cloudnativedays.jp
+    fqdn: tmp.dev.cloudnativedays.jp
+    tls:
+      secretName: cert-manager/wildcard-dev-cloudnativedays-jp
+  routes:
+    - conditions:
+      - prefix: /
+      services:
+      - name: dreamkast-weaver
+        port: 8080
+      cookieRewritePolicies:
+      - name: _session_id
+        secure: true

--- a/manifests/app/dreamkast/overlays/staging/main/kustomization.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 patchesStrategicMerge:
 - deployment-dreamkast.yaml
 - deployment-dreamkast-ui.yaml
+- deployment-dreamkast-weaver.yaml
 namespace: dreamkast-staging
 images:
 - name: dreamkast-ecs
@@ -20,3 +21,9 @@ images:
 - name: dreamkast-ui
   newName: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ui
   newTag: 950030f7ed0ea3fa1a9263a167a99191785a5ec9
+- name: dreamkast-weaver-initdb
+  newName: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-weaver/initdb
+  newTag: latest
+- name: dreamkast-weaver-serve
+  newName: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-weaver/serve
+  newTag: latest

--- a/manifests/app/dreamkast/overlays/staging/main/kustomization.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/kustomization.yaml
@@ -21,9 +21,6 @@ images:
 - name: dreamkast-ui
   newName: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ui
   newTag: 950030f7ed0ea3fa1a9263a167a99191785a5ec9
-- name: dreamkast-weaver-initdb
-  newName: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-weaver/initdb
-  newTag: latest
-- name: dreamkast-weaver-serve
-  newName: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-weaver/serve
+- name: dreamkast-weaver
+  newName: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-weaver
   newTag: latest


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- [dreamkast-weaver](https://github.com/cloudnativedaysjp/dreamkast-weaver)のmanifestをstagingに追加
  - dk/dk-uiと同じnamespaceに作成
- 追加したリソース
  - Service
    - dk/dk-uiはNodePortが設定されてましたが、設定理由がよく分からなかったのでClusterIPに変更しています。
    - port番号はキメです
  - HTTPProxy
    - fqdnは一旦`tmp.dev.cloudnativedays.jp`としています
      - `api.dev.cloudnativedays.jp`とするべきなのですが、dk-function側でまだ利用しているので、一時的なドメインで実装をすすめ、別途切り替える予定です
  - Deployment
    - Prove周りは既存のdeploymentを参考に設定しています

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I have checked backward/forward compatibility that may cause regarding this change.

- 確認したこと
  - 下記コマンドでdevデプロイできることを確認
    ```bash
    kustomize build manifests/app/dreamkast/overlays/staging/main/ | kubectl apply -l tier=dreamkast-weaver -f -
    ```
  - `https://tmp.dev.cloudnativedays.jp/`に接続できることを確認

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
