### PR TITLE
Remove m3.xlarge

### DIFF
--- a/cfn/eks-nodes-bottlerocket.yaml
+++ b/cfn/eks-nodes-bottlerocket.yaml
@@ -46,7 +46,6 @@ Resources:
       InstanceTypes:
         - m5.xlarge
         - m4.xlarge
-        - m3.xlarge
         - t3.xlarge
         - t2.xlarge
       CapacityType: SPOT


### PR DESCRIPTION
# Description

Remove m3.xlarge from the list of nodegroup because it doesn't support client ip preservation.
https://docs.aws.amazon.com/ja_jp/elasticloadbalancing/latest/network/load-balancer-target-groups.html#client-ip-preservation

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
