### PR TITLE
Change tag from 6.0.5 to 6.0

### DIFF
--- a/manifests/app/dreamkast/overlays/development/template-dk/kustomization.yaml
+++ b/manifests/app/dreamkast/overlays/development/template-dk/kustomization.yaml
@@ -45,4 +45,4 @@ images:
   newTag: "8.0.33"
 - name: redis
   newName: public.ecr.aws/docker/library/redis
-  newTag: "6.0.5"
+  newTag: "6.0"

--- a/manifests/app/dreamkast/overlays/staging/main/redis.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/redis.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: redis:6.0.5
+        image: public.ecr.aws/docker/library/redis:6.0
         command:
           - redis-server
           - "/redis-master/redis.conf"


### PR DESCRIPTION
# Description

Change redis image tag from 6.0.5 to 6.0.
Because Amazon ECR public registry doesn't have 6.0.5 tag.
https://gallery.ecr.aws/docker/library/redis

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
