### PR TITLE
fix: rollback to 7da9927

### DIFF
--- a/manifests/infra/contour/overlays/production/kustomization.yaml
+++ b/manifests/infra/contour/overlays/production/kustomization.yaml
@@ -1,8 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
+# In case you want to update contour in a specific environment, you can also use this static resource
+# resources:
+# - https://projectcontour.io/quickstart/v1.18.2/contour.yaml
+bases:
 - ../../base
-# renovate: type=projectcontour/contour
-- https://projectcontour.io/quickstart/v1.24.1/contour.yaml
 patchesStrategicMerge:
 - ./lb-internet-facing.yaml


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

PRDのcontourで`kustomize build`に失敗していたので修正しました。

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I have checked backward/forward compatibility that may cause regarding this change.

- 修正前
  ```
  $ kustomize build overlays/production/ | head
  # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
  # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
  Error: accumulating resources: accumulation err='merging resources from 'https://projectcontour.io/quickstart/v1.24.1/contour.yaml': may not add resource with an already registered id: Namespace.v1.[noGrp]/projectcontour.[noNs]': failed to run '/usr/bin/git fetch --depth=1 https://projectcontour.io/quickstart/v1.24.1 HEAD': fatal: repository 'https://projectcontour.io/quickstart/v1.24.1/' not found
  : exit status 128
  ```
- 修正後
  ```
  $ kustomize build overlays/production/ | head
  # Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
  # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
  # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
  apiVersion: v1
  kind: Namespace
  metadata:
    name: projectcontour
  ---
  apiVersion: apiextensions.k8s.io/v1
  kind: CustomResourceDefinition
  metadata:
    annotations:
      controller-gen.kubebuilder.io/version: v0.11.2
  ```


<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
