### PR TITLE
fix: prometheus

### DIFF
--- a/manifests/infra/prometheus/base/kustomization.yaml
+++ b/manifests/infra/prometheus/base/kustomization.yaml
@@ -2,9 +2,32 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: monitoring
 resources:
+# renovate: type=remote-file
+- https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.0/bundle.yaml
+# renovate: type=remote-file
+- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-serviceAccount.yaml
+# renovate: type=remote-file
+- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-clusterRole.yaml
+# renovate: type=remote-file
+- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-clusterRoleBinding.yaml
+# renovate: type=remote-file
+- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-prometheus.yaml
+# renovate: type=remote-file
+- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-service.yaml
+# renovate: type=remote-file
+- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-serviceMonitor.yaml
+# renovate: type=remote-file
+- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-serviceAccount.yaml
+# renovate: type=remote-file
+- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-clusterRole.yaml
+# renovate: type=remote-file
+- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-clusterRoleBinding.yaml
+# renovate: type=remote-file
+- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-daemonset.yaml
+# renovate: type=remote-file
+- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-service.yaml
 - prometheus-clusterrole.yaml # 本当は同じようにリモートから取得したいが、ClusterRoleがないのでしょうがなく手元で管理している
 - monitor.yaml
 - alertmanager.yaml
-- alert-rules.yaml
 patchesStrategicMerge:
 - prometheus-crd.yaml

--- a/manifests/infra/prometheus/overlays/development/kustomization.yaml
+++ b/manifests/infra/prometheus/overlays/development/kustomization.yaml
@@ -3,29 +3,5 @@ kind: Kustomization
 resources:
 - ../../base
 - slack-secrets.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.0/bundle.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-serviceAccount.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-clusterRole.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-clusterRoleBinding.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-prometheus.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-service.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-serviceMonitor.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-serviceAccount.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-clusterRole.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-clusterRoleBinding.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-daemonset.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-service.yaml
 patchesStrategicMerge:
 - service-monitor-dk.yaml

--- a/manifests/infra/prometheus/overlays/production/kustomization.yaml
+++ b/manifests/infra/prometheus/overlays/production/kustomization.yaml
@@ -3,29 +3,5 @@ kind: Kustomization
 resources:
 - ../../base
 - slack-secrets.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.0/bundle.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-serviceAccount.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-clusterRole.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-clusterRoleBinding.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-prometheus.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/prometheus-service.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-serviceMonitor.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-serviceAccount.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-clusterRole.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-clusterRoleBinding.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-daemonset.yaml
-# renovate: type=remote-file
-- https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.11.0/manifests/nodeExporter-service.yaml
 patchesStrategicMerge:
 - prometheus.yaml


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- `kustmoize build`に失敗していたので修正しました
  - alert-rules.yamlが無くて死んでいた
  - `xxx must resolve to a file: recursed accumulation of path`と言われ死んでいた
    - ぱっとみ、https://github.com/cloudnativedaysjp/dreamkast-infra/pull/2574 と同じに見えた

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I have checked backward/forward compatibility that may cause regarding this change.

- 修正前
  <details>

  ```
  fujii@ubuntu:/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus$ kustomize build overlays/production/ | head
  # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
  # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
  Error: accumulating resources: accumulation err='accumulating resources from '../../base': '/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus/base' must resolve to a file': recursed accumulation of path '/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus/base': accumulating resources: accumulation err='accumulating resources from 'alert-rules.yaml': evalsymlink failure on '/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus/base/alert-rules.yaml' : lstat /data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus/base/alert-rules.yaml: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on '/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus/base/alert-rules.yaml' : lstat /data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus/base/alert-rules.yaml: no such file or directory
  fujii@ubuntu:/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus$ 
  fujii@ubuntu:/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus$ 
  fujii@ubuntu:/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus$ kustomize build overlays/development/ | head
  # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
  # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
  Error: accumulating resources: accumulation err='accumulating resources from '../../base': '/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus/base' must resolve to a file': recursed accumulation of path '/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus/base': accumulating resources: accumulation err='accumulating resources from 'alert-rules.yaml': evalsymlink failure on '/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus/base/alert-rules.yaml' : lstat /data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus/base/alert-rules.yaml: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on '/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus/base/alert-rules.yaml' : lstat /data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus/base/alert-rules.yaml: no such file or directory
  ```
  <./details>

- 修正後、`kustmoize build`が通ることを確認
  <details>

  ```
  fujii@ubuntu:/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus$ kustomize build overlays/development/ | head
  # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
  # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
  apiVersion: apiextensions.k8s.io/v1
  kind: CustomResourceDefinition
  metadata:
    annotations:
      controller-gen.kubebuilder.io/version: v0.9.2
    creationTimestamp: null
    name: alertmanagerconfigs.monitoring.coreos.com
  spec:
    group: monitoring.coreos.com
    names:
  fujii@ubuntu:/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus$ 
  fujii@ubuntu:/data/ghq/github.com/cloudnativedaysjp/dreamkast-infra/manifests/infra/prometheus$ kustomize build overlays/production/ | head
  # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
  # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
  apiVersion: apiextensions.k8s.io/v1
  kind: CustomResourceDefinition
  metadata:
    annotations:
      controller-gen.kubebuilder.io/version: v0.9.2
    creationTimestamp: null
    name: alertmanagerconfigs.monitoring.coreos.com
  spec:
    group: monitoring.coreos.com
    names:
  ```

  </details>


<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
