### PR TITLE
Support Pod readiness gates

### DIFF
--- a/manifests/app/dreamkast/overlays/staging/main/ingress.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/ingress.yaml
@@ -19,12 +19,6 @@ spec:
       cookieRewritePolicies:
       - name: _session_id
         secure: true
-      healthCheckPolicy:
-        path: /
-        intervalSeconds: 5
-        timeoutSeconds: 1
-        unhealthyThresholdCount: 3
-        healthyThresholdCount: 5
     - conditions:
       - prefix: /cable
       enableWebsockets: true

--- a/manifests/infra/argocd-apps/development/contour.yaml
+++ b/manifests/infra/argocd-apps/development/contour.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: contour
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: manifests/infra/contour/overlays/development
+    repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/manifests/infra/contour/base/kustomization.yaml
+++ b/manifests/infra/contour/base/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: projectcontour
 resources:
+- namespace.yaml
 - auth-server.yaml
 - cluster-issuer.yaml

--- a/manifests/infra/contour/base/namespace.yaml
+++ b/manifests/infra/contour/base/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: projectcontour
+  labels:
+    elbv2.k8s.aws/pod-readiness-gate-inject: enabled


### PR DESCRIPTION
* support Pod readiness gates for rollout without down
    * https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/deploy/pod_readiness_gate/
* revert these PRs
    * #2629
    * #2621