### PR TITLE
fix: Persist mysql-o11y data to avoid data loss when restarted

### DIFF
--- a/manifests/infra/mysql-o11y/base/deployment.yaml
+++ b/manifests/infra/mysql-o11y/base/deployment.yaml
@@ -45,3 +45,23 @@ spec:
         ports:
         - containerPort: 3306
           name: mysql
+        volumeMounts:
+        - name: mysql-data
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-data
+        persistentVolumeClaim:
+          claimName: mysql-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-data
+  labels:
+    app: mysql-o11y
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
mysql-o11yが再起動の都度dataが削除されてしまい、次のdaily batchが来るまでdataが空のまま -> telegrafが死んでしまう、という事象をさけるために、PVCをmountしてmysql dataを永続化します。

PVC mountするだけなのと運用ツールなので、devで確認してからprodと細かくstep踏まなくてもいいかなと思い、baseの方を更新してしまってます。devとprodの両方に適用されます。