### PR TITLE
Prod eks rebuild

### DIFF
--- a/manifests/app/argocd-apps/production/dreamkast-main.yaml
+++ b/manifests/app/argocd-apps/production/dreamkast-main.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     path: manifests/app/dreamkast/overlays/production/main
     repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
-    targetRevision: main
+    targetRevision: prod_eks-rebuild
   syncPolicy:
     automated:
       prune: true

--- a/manifests/app/dreamkast/overlays/production/main/cronjob.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/cronjob.yaml
@@ -22,15 +22,15 @@ spec:
                 - name: RAILS_ENV
                   value: "production"
                 - name: MYSQL_HOST
-                  value: "dreamkast-prd-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+                  value: "dreamkast-prod-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
                 - name: MYSQL_DATABASE
                   value: "dreamkast"
                 - name: REDIS_URL
-                  value: "redis://drr7wdanp39n8i1.bp6loy.ng.0001.apne1.cache.amazonaws.com:6379"
+                  value: "redis://dreamkast-prod-redis.bp6loy.ng.0001.apne1.cache.amazonaws.com:6379"
                 - name: SENTRY_DSN
                   value: "https://0d4c2684ad8348bf9c6364619f8fd63a@sentry.cloudnativedays.jp/3"
                 - name: S3_BUCKET
-                  value: "dreamkast-prd-bucket"
+                  value: "dreamkast-prod-bucket"
                 - name: S3_REGION
                   value: ap-northeast-1
                 - name: DREAMKAST_NAMESPACE

--- a/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast-weaver.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast-weaver.yaml
@@ -9,7 +9,7 @@ spec:
       - name: dkw-dbmigrate
         env:
         - name: DB_ENDPOINT
-          value: "dreamkast-prd-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+          value: "dreamkast-prod-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
         - name: DB_PORT
           value: "3306"
         - name: DB_USER
@@ -26,7 +26,7 @@ spec:
       - name: dkw-serve
         env:
         - name: DB_ENDPOINT
-          value: "dreamkast-prd-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+          value: "dreamkast-prod-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
         - name: DB_PORT
           value: "3306"
         - name: DB_USER

--- a/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast.yaml
@@ -34,15 +34,15 @@ spec:
         - name: RAILS_ENV
           value: "production"
         - name: MYSQL_HOST
-          value: "dreamkast-prd-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+          value: "dreamkast-prod-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
         - name: MYSQL_DATABASE
           value: "dreamkast"
         - name: REDIS_URL
-          value: "redis://drr7wdanp39n8i1.bp6loy.ng.0001.apne1.cache.amazonaws.com:6379"
+          value: "redis://dreamkast-prod-redis.bp6loy.ng.0001.apne1.cache.amazonaws.com:6379"
         - name: SENTRY_DSN
           value: "https://07f87d11da2c44189d03593537edb291@sentry.cloudnativedays.jp/2"
         - name: S3_BUCKET
-          value: "dreamkast-prd-bucket"
+          value: "dreamkast-prod-bucket"
         - name: S3_REGION
           value: ap-northeast-1
         - name: SQS_FIFO_QUEUE_URL
@@ -97,23 +97,23 @@ spec:
         - name: RAILS_ENV
           value: "production"
         - name: MYSQL_HOST
-          value: "dreamkast-prd-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+          value: "dreamkast-prod-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
         - name: MYSQL_DATABASE
           value: "dreamkast"
         - name: REDIS_URL
-          value: "redis://drr7wdanp39n8i1.bp6loy.ng.0001.apne1.cache.amazonaws.com:6379"
+          value: "redis://dreamkast-prod-redis.bp6loy.ng.0001.apne1.cache.amazonaws.com:6379"
         - name: SENTRY_DSN
           value: "https://07f87d11da2c44189d03593537edb291@sentry.cloudnativedays.jp/2"
         - name: OTEL_SERVICE_NAME
           value: "dreamkast"
         - name: S3_BUCKET
-          value: "dreamkast-prd-bucket"
+          value: "dreamkast-prod-bucket"
         - name: S3_REGION
           value: ap-northeast-1
         - name: AWS_REGION
           value: ap-northeast-1
         - name: SQS_FIFO_QUEUE_URL
-          value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-prdFifoQueue.fifo"
+          value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-prod-fifo-queue.fifo"
         - name: DREAMKAST_API_ADDR
           value: "https://api.cloudnativedays.jp"
         # TODO: Delete DREAMKAST_WEAVER_ADDR

--- a/manifests/app/dreamkast/overlays/production/main/deployment-fifo-worker.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/deployment-fifo-worker.yaml
@@ -31,23 +31,23 @@ spec:
         - name: RAILS_ENV
           value: "production"
         - name: MYSQL_HOST
-          value: "dreamkast-prd-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+          value: "dreamkast-prod-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
         - name: MYSQL_DATABASE
           value: "dreamkast"
         - name: REDIS_URL
-          value: "redis://drr7wdanp39n8i1.bp6loy.ng.0001.apne1.cache.amazonaws.com:6379"
+          value: "redis://dreamkast-prod-redis.bp6loy.ng.0001.apne1.cache.amazonaws.com:6379"
         - name: SENTRY_DSN
           value: "https://07f87d11da2c44189d03593537edb291@sentry.cloudnativedays.jp/2"
         - name: OTEL_SERVICE_NAME
           value: "dreamkast-fifo-worker"
         - name: S3_BUCKET
-          value: "dreamkast-prd-bucket"
+          value: "dreamkast-prod-bucket"
         - name: S3_REGION
           value: ap-northeast-1
         - name: AWS_REGION
           value: ap-northeast-1
         - name: SQS_FIFO_QUEUE_URL
-          value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-prdFifoQueue.fifo"
+          value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-prod-fifo-queue.fifo"
         - name: DREAMKAST_NAMESPACE
           valueFrom:
             fieldRef:

--- a/manifests/app/dreamkast/overlays/production/main/polling-harvest-job-and-update-video.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/polling-harvest-job-and-update-video.yaml
@@ -21,23 +21,23 @@ spec:
                 - name: RAILS_ENV
                   value: "production"
                 - name: MYSQL_HOST
-                  value: "dreamkast-prd-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
+                  value: "dreamkast-prod-rds.c6eparu1hmbv.ap-northeast-1.rds.amazonaws.com"
                 - name: MYSQL_DATABASE
                   value: "dreamkast"
                 - name: REDIS_URL
-                  value: "redis://dreamkast-redis:6379"
+                  value: "redis://dreamkast-prod-redis.bp6loy.ng.0001.apne1.cache.amazonaws.com:6379"
                 - name: SENTRY_DSN
                   value: "https://0d4c2684ad8348bf9c6364619f8fd63a@sentry.cloudnativedays.jp/3"
                 - name: OTEL_SERVICE_NAME
                   value: "dreamkast-harvest-job"
                 - name: S3_BUCKET
-                  value: "dreamkast-prd-bucket"
+                  value: "dreamkast-prod-bucket"
                 - name: S3_REGION
                   value: ap-northeast-1
                 - name: AWS_REGION
                   value: ap-northeast-1
                 - name: SQS_MAIL_QUEUE_URL
-                  value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-prdMailQueue.fifo"
+                  value: "https://sqs.ap-northeast-1.amazonaws.com/607167088920/dreamkast-prod-mail-queue.fifo"
                 - name: SLACK_WEBHOOK_URL
                   valueFrom:
                     secretKeyRef:

--- a/manifests/app/dreamkast/overlays/production/main/secret.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/secret.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   backendType: secretsManager
   data:
-    - key: MyRDSSecret-kEkmCRc4oDcs
+    - key: dreamkast-prod-rds-secret
       name: password
       property: password
-    - key: MyRDSSecret-kEkmCRc4oDcs
+    - key: dreamkast-prod-rds-secret
       name: username
       property: username
 ---

--- a/manifests/argocd-apps/production/argocd.yaml
+++ b/manifests/argocd-apps/production/argocd.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
     path: manifests/argocd/overlays/prd
-    targetRevision: main
+    targetRevision: prod_eks-rebuild
   syncPolicy:
     automated:
       prune: true

--- a/manifests/argocd-apps/production/dreamkast.yaml
+++ b/manifests/argocd-apps/production/dreamkast.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     path: manifests/app/argocd-apps/production
     repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
-    targetRevision: main
+    targetRevision: prod_eks-rebuild
   syncPolicy:
     automated:
       prune: true

--- a/manifests/argocd-apps/production/infra.yaml
+++ b/manifests/argocd-apps/production/infra.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     path: manifests/infra/argocd-apps/production
     repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
-    targetRevision: main
+    targetRevision: prod_eks-rebuild
   syncPolicy:
     automated:
       prune: true

--- a/manifests/argocd/overlays/dev-with-secrets/kustomization.yaml
+++ b/manifests/argocd/overlays/dev-with-secrets/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: argocd
 resources:
 - ../dev

--- a/manifests/argocd/overlays/dev/argocd-cm.yaml
+++ b/manifests/argocd/overlays/dev/argocd-cm.yaml
@@ -41,6 +41,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-notifications-cm
+  namespace: argocd
 data:
   service.slack: |
     token: $slack-token

--- a/manifests/argocd/overlays/dev/delete-secret.yaml
+++ b/manifests/argocd/overlays/dev/delete-secret.yaml
@@ -4,9 +4,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: argocd-secret
+  namespace: argocd
 ---
 $patch: delete
 apiVersion: v1
 kind: Secret
 metadata:
   name: argocd-notifications-secret
+  namespace: argocd

--- a/manifests/argocd/overlays/dev/kustomization.yaml
+++ b/manifests/argocd/overlays/dev/kustomization.yaml
@@ -1,10 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../base
-  - ./projects.yaml
+- ../../base
+- ./projects.yaml
 patchesStrategicMerge:
-  - ./service.yaml
-  - ./argocd-cm.yaml
-  - ./argocd-rbac-cm.yaml
-  - ./delete-secret.yaml
-  - ./pods.yaml
-  - ./notifications-cm.yaml
+- ./service.yaml
+- ./argocd-cm.yaml
+- ./argocd-rbac-cm.yaml
+- ./delete-secret.yaml
+- ./pods.yaml
+- ./notifications-cm.yaml

--- a/manifests/argocd/overlays/dev/notifications-cm.yaml
+++ b/manifests/argocd/overlays/dev/notifications-cm.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-notifications-cm
+  namespace: argocd
 data:
   template.app-created: |
     message: Application {{.app.metadata.name}} has been created.

--- a/manifests/argocd/overlays/dev/pods.yaml
+++ b/manifests/argocd/overlays/dev/pods.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: argocd-application-controller
+  namespace: argocd
 spec:
   template:
     spec:
@@ -20,6 +21,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: argocd-server
+  namespace: argocd
 spec:
   template:
     spec:
@@ -42,6 +44,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: argocd-dex-server
+  namespace: argocd
 spec:
   template:
     spec:
@@ -59,6 +62,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: argocd-redis
+  namespace: argocd
 spec:
   template:
     spec:
@@ -76,6 +80,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: argocd-repo-server
+  namespace: argocd
 spec:
   template:
     spec:

--- a/manifests/argocd/overlays/dev/service.yaml
+++ b/manifests/argocd/overlays/dev/service.yaml
@@ -4,3 +4,4 @@ metadata:
   labels:
     projectcontour.io/upstream-protocol.h2c: "443"
   name: argocd-server
+  namespace: argocd

--- a/manifests/argocd/overlays/prd-with-secrets/kustomization.yaml
+++ b/manifests/argocd/overlays/prd-with-secrets/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: argocd
 resources:
 - ../prd

--- a/manifests/argocd/overlays/prd/argocd-cm.yaml
+++ b/manifests/argocd/overlays/prd/argocd-cm.yaml
@@ -22,4 +22,4 @@ data:
     - profile
     - email
     - 'https://cloudnativedays.jp/claims/groups'
-  admin.enabled: "false"
+  admin.enabled: "true"

--- a/manifests/argocd/overlays/prd/kustomization.yaml
+++ b/manifests/argocd/overlays/prd/kustomization.yaml
@@ -1,6 +1,8 @@
-bases:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../base
-patches:
+patchesStrategicMerge:
 - ./service.yaml
 - ./argocd-cm.yaml
 - ./argocd-rbac-cm.yaml

--- a/manifests/infra/argocd-apps/development/external-snapshotter.yaml
+++ b/manifests/infra/argocd-apps/development/external-snapshotter.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-snapshotter
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: manifests/infra/external-snapshotter/overlays/development
+    repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/manifests/infra/argocd-apps/development/storage.yaml
+++ b/manifests/infra/argocd-apps/development/storage.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: storage
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: manifests/infra/storage/overlays/development
+    repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/manifests/infra/argocd-apps/production/aws-cluster-autoscaler.yaml
+++ b/manifests/infra/argocd-apps/production/aws-cluster-autoscaler.yaml
@@ -19,7 +19,7 @@ spec:
       releaseName: aws-cluster-autoscaler
       parameters:
       - name: autoDiscovery.clusterName
-        value: dreamkast-cluster
+        value: dreamkast-prod-cluster
       - name: awsRegion
         value: ap-northeast-1
       - name: rbac.serviceAccount.create

--- a/manifests/infra/argocd-apps/production/aws-ebs-csi-driver.yaml
+++ b/manifests/infra/argocd-apps/production/aws-ebs-csi-driver.yaml
@@ -14,7 +14,7 @@ spec:
   source:
     chart: aws-ebs-csi-driver
     repoURL: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
-    targetRevision: 2.19.0
+    targetRevision: 2.21.0
     helm:
       parameters:
       - name: controller.region

--- a/manifests/infra/argocd-apps/production/aws-load-balancer-controller.yaml
+++ b/manifests/infra/argocd-apps/production/aws-load-balancer-controller.yaml
@@ -19,7 +19,7 @@ spec:
       releaseName: aws-load-balancer-controller
       parameters:
       - name: clusterName
-        value: dreamkast-cluster
+        value: dreamkast-prod-cluster
       - name: serviceAccount.create
         value: "false"
       - name: serviceAccount.name

--- a/manifests/infra/argocd-apps/production/external-snapshotter.yaml
+++ b/manifests/infra/argocd-apps/production/external-snapshotter.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-snapshotter
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: manifests/infra/external-snapshotter/overlays/production
+    repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
+    targetRevision: prod_eks-rebuild
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/manifests/infra/argocd-apps/production/grafana.yaml
+++ b/manifests/infra/argocd-apps/production/grafana.yaml
@@ -169,8 +169,8 @@ spec:
         - name: persistence.type
           value: statefulset
   syncPolicy:
-    automated:
-      prune: true
+    #automated:
+    #  prune: true
     syncOptions:
       - CreateNamespace=true
 ---

--- a/manifests/infra/argocd-apps/production/grafana.yaml
+++ b/manifests/infra/argocd-apps/production/grafana.yaml
@@ -169,8 +169,8 @@ spec:
         - name: persistence.type
           value: statefulset
   syncPolicy:
-    #automated:
-    #  prune: true
+    automated:
+      prune: true
     syncOptions:
       - CreateNamespace=true
 ---

--- a/manifests/infra/argocd-apps/production/grafana.yaml
+++ b/manifests/infra/argocd-apps/production/grafana.yaml
@@ -177,7 +177,7 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: grafana-ingress
+  name: grafana-configs
   namespace: argocd
 spec:
   destination:
@@ -185,7 +185,7 @@ spec:
     server: https://kubernetes.default.svc
   project: monitoring
   source:
-    path: manifests/infra/grafana-ingress/overlays/production
+    path: manifests/infra/grafana/overlays/production
     repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
     targetRevision: main
   syncPolicy:

--- a/manifests/infra/argocd-apps/production/mysql-o11y.yaml
+++ b/manifests/infra/argocd-apps/production/mysql-o11y.yaml
@@ -16,7 +16,7 @@ spec:
     repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
     targetRevision: main
   syncPolicy:
-    #automated:
-    #  prune: true
+    automated:
+      prune: true
     syncOptions:
     - CreateNamespace=true

--- a/manifests/infra/argocd-apps/production/mysql-o11y.yaml
+++ b/manifests/infra/argocd-apps/production/mysql-o11y.yaml
@@ -16,7 +16,7 @@ spec:
     repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
     targetRevision: main
   syncPolicy:
-    automated:
-      prune: true
+    #automated:
+    #  prune: true
     syncOptions:
     - CreateNamespace=true

--- a/manifests/infra/argocd-apps/production/prometheus-pushgateway.yaml
+++ b/manifests/infra/argocd-apps/production/prometheus-pushgateway.yaml
@@ -13,7 +13,7 @@ spec:
   project: monitoring
   source:
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 2.1.6
+    targetRevision: 2.4.0
     chart: prometheus-pushgateway
     helm:
       values: |

--- a/manifests/infra/argocd-apps/production/prometheus-pushgateway.yaml
+++ b/manifests/infra/argocd-apps/production/prometheus-pushgateway.yaml
@@ -22,6 +22,7 @@ spec:
           interval: 5s
         persistentVolume:
           enabled: true
+          existingClaim: "prometheus-pushgateway"
   syncPolicy:
     automated:
       prune: true

--- a/manifests/infra/argocd-apps/production/prometheus-pushgateway.yaml
+++ b/manifests/infra/argocd-apps/production/prometheus-pushgateway.yaml
@@ -23,7 +23,7 @@ spec:
         persistentVolume:
           enabled: true
   syncPolicy:
-    automated:
-      prune: true
+    #automated:
+    #  prune: true
     syncOptions:
     - CreateNamespace=true

--- a/manifests/infra/argocd-apps/production/prometheus-pushgateway.yaml
+++ b/manifests/infra/argocd-apps/production/prometheus-pushgateway.yaml
@@ -23,7 +23,7 @@ spec:
         persistentVolume:
           enabled: true
   syncPolicy:
-    #automated:
-    #  prune: true
+    automated:
+      prune: true
     syncOptions:
     - CreateNamespace=true

--- a/manifests/infra/argocd-apps/production/prometheus.yaml
+++ b/manifests/infra/argocd-apps/production/prometheus.yaml
@@ -16,7 +16,7 @@ spec:
     repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
     targetRevision: main
   syncPolicy:
-    #automated:
-    #  prune: true
+    automated:
+      prune: true
     syncOptions:
     - CreateNamespace=true

--- a/manifests/infra/argocd-apps/production/prometheus.yaml
+++ b/manifests/infra/argocd-apps/production/prometheus.yaml
@@ -16,7 +16,7 @@ spec:
     repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
     targetRevision: main
   syncPolicy:
-    automated:
-      prune: true
+    #automated:
+    #  prune: true
     syncOptions:
     - CreateNamespace=true

--- a/manifests/infra/argocd-apps/production/storage.yaml
+++ b/manifests/infra/argocd-apps/production/storage.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: storage
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: manifests/infra/storage/overlays/production
+    repoURL: https://github.com/cloudnativedaysjp/dreamkast-infra.git
+    targetRevision: prod_eks-rebuild
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/manifests/infra/external-snapshotter/overlays/development/kustomization.yaml
+++ b/manifests/infra/external-snapshotter/overlays/development/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+# renovate: type=remote-directory
+- https://github.com/kubernetes-csi/external-snapshotter/client/config/crd?ref=v6.2.2
+# renovate: type=remote-directory
+- https://github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller?ref=v6.2.2

--- a/manifests/infra/external-snapshotter/overlays/production/kustomization.yaml
+++ b/manifests/infra/external-snapshotter/overlays/production/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+# renovate: type=remote-directory
+- https://github.com/kubernetes-csi/external-snapshotter/client/config/crd?ref=v6.2.2
+# renovate: type=remote-directory
+- https://github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller?ref=v6.2.2

--- a/manifests/infra/storage/base/kustomization.yaml
+++ b/manifests/infra/storage/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./sc_gp2.yaml
+- ./sc_ebs-sc.yaml
+- ./vsc_ebs-csi.yaml

--- a/manifests/infra/storage/base/sc_ebs-sc.yaml
+++ b/manifests/infra/storage/base/sc_ebs-sc.yaml
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  name: ebs-sc
+provisioner: ebs.csi.aws.com
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  csi.storage.k8s.io/fstype: xfs
+  encrypted: "true"
+  type: gp3
+allowVolumeExpansion: true

--- a/manifests/infra/storage/base/sc_gp2.yaml
+++ b/manifests/infra/storage/base/sc_gp2.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+  name: gp2
+provisioner: kubernetes.io/aws-ebs
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  fsType: ext4
+  type: gp2

--- a/manifests/infra/storage/base/vsc_ebs-csi.yaml
+++ b/manifests/infra/storage/base/vsc_ebs-csi.yaml
@@ -1,0 +1,6 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: ebs-csi-aws
+driver: ebs.csi.aws.com
+deletionPolicy: Delete

--- a/manifests/infra/storage/overlays/development/kustomization.yaml
+++ b/manifests/infra/storage/overlays/development/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base

--- a/manifests/infra/storage/overlays/production/kustomization.yaml
+++ b/manifests/infra/storage/overlays/production/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- migrate-from-old-cluster/mysql-data.yaml
+- migrate-from-old-cluster/prometheus-k8s-db-prometheus-k8s-0.yaml
+- migrate-from-old-cluster/prometheus-k8s-db-prometheus-k8s-1.yaml
+- migrate-from-old-cluster/prometheus-pushgateway.yaml
+- migrate-from-old-cluster/storage-grafana-0.yaml

--- a/manifests/infra/storage/overlays/production/migrate-from-old-cluster/README.md
+++ b/manifests/infra/storage/overlays/production/migrate-from-old-cluster/README.md
@@ -1,0 +1,3 @@
+### references
+
+* https://aws.amazon.com/jp/blogs/containers/migrating-amazon-eks-clusters-from-gp2-to-gp3-ebs-volumes/

--- a/manifests/infra/storage/overlays/production/migrate-from-old-cluster/mysql-data.yaml
+++ b/manifests/infra/storage/overlays/production/migrate-from-old-cluster/mysql-data.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: mysql-data
+spec:
+  volumeSnapshotRef:
+    kind: VolumeSnapshot
+    name: mysql-data
+    namespace: monitoring
+  source:
+    snapshotHandle: snap-0ba4c6eb62e06d915
+  driver: ebs.csi.aws.com
+  deletionPolicy: Delete
+  volumeSnapshotClassName: ebs-csi-aws
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: mysql-data
+  namespace: monitoring
+spec:
+  volumeSnapshotClassName: ebs-csi-aws
+  source:
+    volumeSnapshotContentName: mysql-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+  name: mysql-data
+  namespace: monitoring
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ebs-sc
+  dataSource:
+    name: mysql-data
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+

--- a/manifests/infra/storage/overlays/production/migrate-from-old-cluster/prometheus-k8s-db-prometheus-k8s-0.yaml
+++ b/manifests/infra/storage/overlays/production/migrate-from-old-cluster/prometheus-k8s-db-prometheus-k8s-0.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: prometheus-k8s-db-prometheus-k8s-0
+spec:
+  volumeSnapshotRef:
+    kind: VolumeSnapshot
+    name: prometheus-k8s-db-prometheus-k8s-0
+    namespace: monitoring
+  source:
+    snapshotHandle: snap-0f41f7268c14c49fc
+  driver: ebs.csi.aws.com
+  deletionPolicy: Delete
+  volumeSnapshotClassName: ebs-csi-aws
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: prometheus-k8s-db-prometheus-k8s-0
+  namespace: monitoring
+spec:
+  volumeSnapshotClassName: ebs-csi-aws
+  source:
+    volumeSnapshotContentName: prometheus-k8s-db-prometheus-k8s-0
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-k8s-db-prometheus-k8s-0
+  namespace: monitoring
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 150Gi
+  storageClassName: ebs-sc
+  dataSource:
+    name: prometheus-k8s-db-prometheus-k8s-0
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io

--- a/manifests/infra/storage/overlays/production/migrate-from-old-cluster/prometheus-k8s-db-prometheus-k8s-1.yaml
+++ b/manifests/infra/storage/overlays/production/migrate-from-old-cluster/prometheus-k8s-db-prometheus-k8s-1.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: prometheus-k8s-db-prometheus-k8s-1
+spec:
+  volumeSnapshotRef:
+    kind: VolumeSnapshot
+    name: prometheus-k8s-db-prometheus-k8s-1
+    namespace: monitoring
+  source:
+    snapshotHandle: snap-0a203e70c814d3d8a
+  driver: ebs.csi.aws.com
+  deletionPolicy: Delete
+  volumeSnapshotClassName: ebs-csi-aws
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: prometheus-k8s-db-prometheus-k8s-1
+  namespace: monitoring
+spec:
+  volumeSnapshotClassName: ebs-csi-aws
+  source:
+    volumeSnapshotContentName: prometheus-k8s-db-prometheus-k8s-1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-k8s-db-prometheus-k8s-1
+  namespace: monitoring
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 150Gi
+  storageClassName: ebs-sc
+  dataSource:
+    name: prometheus-k8s-db-prometheus-k8s-1
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io

--- a/manifests/infra/storage/overlays/production/migrate-from-old-cluster/prometheus-pushgateway.yaml
+++ b/manifests/infra/storage/overlays/production/migrate-from-old-cluster/prometheus-pushgateway.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: prometheus-pushgateway
+spec:
+  volumeSnapshotRef:
+    kind: VolumeSnapshot
+    name: prometheus-pushgateway
+    namespace: monitoring
+  source:
+    snapshotHandle: snap-0c26d27a68f00b6d7
+  driver: ebs.csi.aws.com
+  deletionPolicy: Delete
+  volumeSnapshotClassName: ebs-csi-aws
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: prometheus-pushgateway
+  namespace: monitoring
+spec:
+  volumeSnapshotClassName: ebs-csi-aws
+  source:
+    volumeSnapshotContentName: prometheus-pushgateway
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-pushgateway
+  namespace: monitoring
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: ebs-sc
+  dataSource:
+    name: prometheus-pushgateway
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+

--- a/manifests/infra/storage/overlays/production/migrate-from-old-cluster/storage-grafana-0.yaml
+++ b/manifests/infra/storage/overlays/production/migrate-from-old-cluster/storage-grafana-0.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: storage-grafana-0
+spec:
+  volumeSnapshotRef:
+    kind: VolumeSnapshot
+    name: storage-grafana-0
+    namespace: monitoring
+  source:
+    snapshotHandle: snap-042cde81d2de81413
+  driver: ebs.csi.aws.com
+  deletionPolicy: Delete
+  volumeSnapshotClassName: ebs-csi-aws
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: storage-grafana-0
+  namespace: monitoring
+spec:
+  volumeSnapshotClassName: ebs-csi-aws
+  source:
+    volumeSnapshotContentName: storage-grafana-0
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-grafana-0
+  namespace: monitoring
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: ebs-sc
+  dataSource:
+    name: storage-grafana-0
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io


### PR DESCRIPTION
### 移行手順

* [x] new dev cluster が動作していることを確認する
    1. prod cluster で公開しているサービスの fqdn を取得: `kubectl get httpproxies -A`
        * 今回は例として `event.cloudnativedays.jp` を使用
    2. /etc/hosts に `43.207.21.177 event.cloudnativedays.jp` を設定
    3. ブラウザで https://event.cloudnativedays.jp/ を確認する
* メンテナンスウインドウ ここから ---
    * [x] RDS の dump -> restore
    * [x] S3 の sync
    * [x] DNS レコードの切り替え
        * [x] route53 の *.cloudnativedays.jp の解決先を new prod cluster の NLB に向ける
    * [x] EKS の PersistentVolume の移行
        * https://aws.amazon.com/jp/blogs/containers/migrating-amazon-eks-clusters-from-gp2-to-gp3-ebs-volumes/
* --- メンテナンスウインドウ ここまで
* [ ] この PR を merge する
    * **prod_eks-rebuild ブランチはまだ delete しない**
* [ ] `s/targetRevision: prod_eks-rebuild/targetRevision: main/g` した PR の作成, merge
* [ ] prod_eks-rebuild ブランチを削除
* [ ] cloudnativedaysjp/terraform の更新
    * [ ] dreamkast_infra/prod の更新
        * dreamkast_infra/prod/route53.tf のコメントアウトを外した上で `terraform import aws_route53_record.wildcard_dev_cloudnativedays_jp` する