### PR TITLE
fix/dk-ui: Call dk directly without via proxy

### DIFF
--- a/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast-ui.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/deployment-dreamkast-ui.yaml
@@ -9,7 +9,7 @@ spec:
       - name: dreamkast-ui
         env:
         - name: NEXT_PUBLIC_API_BASE_URL
-          value: https://api.cloudnativedays.jp
+          value: https://event.cloudnativedays.jp
         - name: NEXT_PUBLIC_DK_URL
           value: https://event.cloudnativedays.jp
         - name: NEXT_PUBLIC_WEAVER_URL

--- a/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast-ui.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/deployment-dreamkast-ui.yaml
@@ -9,7 +9,7 @@ spec:
       - name: dreamkast-ui
         env:
         - name: NEXT_PUBLIC_API_BASE_URL
-          value: https://api.stg.cloudnativedays.jp
+          value: https://staging.dev.cloudnativedays.jp
         - name: NEXT_PUBLIC_DK_URL
           value: https://staging.dev.cloudnativedays.jp
         - name: NEXT_PUBLIC_WEAVER_URL


### PR DESCRIPTION
dk-ui -> dkの通信で、api-gatewayを経由しないようにしました（すでに削除されているので）
バグってて動かない状態になっているので、復旧優先でmergeしちゃいます。