### PR TITLE
feat: Switch cndt2023 to cnds2024

### DIFF
--- a/ecspresso/base/const.libsonnet
+++ b/ecspresso/base/const.libsonnet
@@ -1,5 +1,5 @@
 {
   accountID: '607167088920',
   executionRoleName: 'dreamkast-dev-ecs-task-execution-role',
-  eventName: 'cndt2023',  // used by basePath for dreamkast-ui
+  eventName: 'cnds2024',  // used by basePath for dreamkast-ui
 }

--- a/ecspresso/reviewapps/template-ui/initialize.sh
+++ b/ecspresso/reviewapps/template-ui/initialize.sh
@@ -29,7 +29,7 @@ TARGET_GROUP_ARN=$(aws elbv2 create-target-group \
   --port 3000 \
   --vpc-id ${VPC_ID} \
   --ip-address-type ipv4 \
-  --health-check-path "/cndt2023/ui" \
+  --health-check-path "/cnds2024/ui" \
   | jq -r ".TargetGroups[0].TargetGroupArn")
 
 # create ALB ListenerRule

--- a/ecspresso/reviewapps/ui-499/initialize.sh
+++ b/ecspresso/reviewapps/ui-499/initialize.sh
@@ -29,7 +29,7 @@ TARGET_GROUP_ARN=$(aws elbv2 create-target-group \
   --port 3000 \
   --vpc-id ${VPC_ID} \
   --ip-address-type ipv4 \
-  --health-check-path "/cndt2023/ui" \
+  --health-check-path "/cnds2024/ui" \
   | jq -r ".TargetGroups[0].TargetGroupArn")
 
 # create ALB ListenerRule

--- a/manifests/app/dreamkast/base/deployment.yaml
+++ b/manifests/app/dreamkast/base/deployment.yaml
@@ -69,23 +69,23 @@ spec:
         - containerPort: 3001
         env:
         - name: NEXT_PUBLIC_BASE_PATH
-          value: /cndt2023/ui
+          value: /cnds2024/ui
         livenessProbe:
           httpGet:
             port: 3001
-            path: /cndt2023/ui/
+            path: /cnds2024/ui/
           failureThreshold: 5
           periodSeconds: 5
         readinessProbe:
           httpGet:
             port: 3001
-            path: /cndt2023/ui/
+            path: /cnds2024/ui/
           failureThreshold: 5
           periodSeconds: 5
         startupProbe:
           httpGet:
             port: 3001
-            path: /cndt2023/ui/
+            path: /cnds2024/ui/
           failureThreshold: 30
           periodSeconds: 10
         resources:

--- a/manifests/app/dreamkast/overlays/development/template-dk/ingress.yaml
+++ b/manifests/app/dreamkast/overlays/development/template-dk/ingress.yaml
@@ -22,7 +22,7 @@ spec:
       - name: dreamkast
         port: 80
     - conditions: #TODO: Need to resolve this hardcoded routing
-      - prefix: /cndt2023/ui
+      - prefix: /cnds2024/ui
       services:
       - name: dreamkast-ui
         port: 3001

--- a/manifests/app/dreamkast/overlays/development/template-ui/deployment-dreamkast-ui.yaml
+++ b/manifests/app/dreamkast/overlays/development/template-ui/deployment-dreamkast-ui.yaml
@@ -51,7 +51,7 @@ spec:
               name: dreamkast-ui-secret
               key: NEXT_PUBLIC_AUTH0_AUDIENCE
         - name: NEXT_PUBLIC_BASE_PATH
-          value: /cndt2023/ui
+          value: /cnds2024/ui
         - name: NEXT_PUBLIC_EVENT_SALT
           valueFrom:
             secretKeyRef:
@@ -60,19 +60,19 @@ spec:
         livenessProbe:
           httpGet:
             port: 3001
-            path: /cndt2023/ui/
+            path: /cnds2024/ui/
           failureThreshold: 5
           periodSeconds: 5
         readinessProbe:
           httpGet:
             port: 3001
-            path: /cndt2023/ui/
+            path: /cnds2024/ui/
           failureThreshold: 5
           periodSeconds: 5
         startupProbe:
           httpGet:
             port: 3001
-            path: /cndt2023/ui/
+            path: /cnds2024/ui/
           failureThreshold: 30
           periodSeconds: 10
         resources:

--- a/manifests/app/dreamkast/overlays/development/template-ui/ingress.yaml
+++ b/manifests/app/dreamkast/overlays/development/template-ui/ingress.yaml
@@ -11,7 +11,7 @@ spec:
       secretName: cert-manager/wildcard-dev-cloudnativedays-jp
   routes:
     - conditions: #TODO: Need to resolve this hardcoded routing
-      - prefix: /cndt2023/ui
+      - prefix: /cnds2024/ui
       services:
       - name: dreamkast-ui
         port: 3001

--- a/manifests/app/dreamkast/overlays/production/main/ingress.yaml
+++ b/manifests/app/dreamkast/overlays/production/main/ingress.yaml
@@ -35,7 +35,7 @@ spec:
       - name: X-Contour-Session-Affinity
         secure: true
     - conditions:
-      - prefix: /cndt2023/ui
+      - prefix: /cnds2024/ui
       services:
       - name: dreamkast-ui
         port: 3001

--- a/manifests/app/dreamkast/overlays/staging/main/ingress.yaml
+++ b/manifests/app/dreamkast/overlays/staging/main/ingress.yaml
@@ -31,7 +31,7 @@ spec:
       - name: _session_id
         secure: true
     - conditions:
-      - prefix: /cndt2023/ui
+      - prefix: /cnds2024/ui
       services:
       - name: dreamkast-ui
         port: 3001


### PR DESCRIPTION
cndt2023に向いていたものを全てcnds2024にかえました。

ecspressoの方はよくわかってないのですが、cndt2023である必要はないと思い変えています。