### PR TITLE
Add log router and mackerel agent for dreamakast staging

### DIFF
--- a/ecspresso/base/dreamkast.libsonnet
+++ b/ecspresso/base/dreamkast.libsonnet
@@ -159,7 +159,7 @@ local const = import './const.libsonnet';
         dependsOn: [
           {
             containerName: 'log_router',
-            condition: 'HEALTHY',
+            condition: 'START',
           },
         ]
       } + if enableLogging then {
@@ -234,7 +234,7 @@ local const = import './const.libsonnet';
         name: 'log_router',
         image: 'grafana/fluent-bit-plugin-loki:2.9.10',
         cpu: 0,
-        memoryReservation: 50,
+        memoryReservation: 128,
         environment: [],
         secrets: [],
         firelensConfiguration: {

--- a/ecspresso/base/dreamkast.libsonnet
+++ b/ecspresso/base/dreamkast.libsonnet
@@ -177,8 +177,8 @@ local const = import './const.libsonnet';
       } else {},
       root.containerDefinitionCommon {
         name: 'dreamkast',
-        cpu: 448,
-        memoryReservation: 896,
+        cpu: 256,
+        memoryReservation: 512,
         essential: true,
         environment: root.containerDefinitionCommon.environment + [
           {
@@ -234,7 +234,7 @@ local const = import './const.libsonnet';
         name: 'log_router',
         image: 'grafana/fluent-bit-plugin-loki:2.9.10',
         cpu: 0,
-        memoryReservation: 128,
+        memoryReservation: 192,
         environment: [],
         secrets: [],
         firelensConfiguration: {
@@ -258,7 +258,7 @@ local const = import './const.libsonnet';
         name: 'mackerel-container-agent',
         image: 'mackerel/mackerel-container-agent:latest',
         cpu: 0,
-        memoryReservation: 128,
+        memoryReservation: 192,
         environment: [
           {
             name: 'MACKEREL_CONTAINER_PLATFORM',

--- a/ecspresso/base/dreamkast.libsonnet
+++ b/ecspresso/base/dreamkast.libsonnet
@@ -235,10 +235,12 @@ local const = import './const.libsonnet';
         image: 'grafana/fluent-bit-plugin-loki:2.9.10',
         cpu: 0,
         memoryReservation: 50,
+        environment: [],
+        secrets: [],
         firelensConfiguration: {
-        　'type': 'fluentbit',
-          'options': {
-            'enable-ecs-log-metadata': 'true'
+          type: 'fluentbit',
+          options: {
+            'enable-ecs-log-metadata': 'true',
           }
         }
       } + if enableLogging then {

--- a/ecspresso/base/dreamkast.libsonnet
+++ b/ecspresso/base/dreamkast.libsonnet
@@ -268,7 +268,7 @@ local const = import './const.libsonnet';
         secrets: [
           {
             valueFrom: 'arn:aws:secretsmanager:%s:%s:secret:%s' % [region, const.accountID, mackerelSecretManagerName],
-            name: 'MACKEREL_CONTAINER_PLATFORM',
+            name: 'MACKEREL_APIKEY',
           },
         ],
       } + if enableLogging then {

--- a/ecspresso/stg/const.libsonnet
+++ b/ecspresso/stg/const.libsonnet
@@ -33,6 +33,7 @@
     dkUi: 'dreamkast-ui/staging-env-3nBcuB',
     railsApp: 'dreamkast/rails-app-secret-SqidNC',
     rds: 'dreamkast-stg-rds-secret-0dsVhM',
+    mackerel: 'observability/mackerel/api-key-tjOHnb',
   },
   sentry: {
     dsn: 'TODO',

--- a/ecspresso/stg/const.libsonnet
+++ b/ecspresso/stg/const.libsonnet
@@ -3,6 +3,7 @@
     dk: 'https://staging.dev.cloudnativedays.jp',
     dkApi: 'https://api.stg.cloudnativedays.jp',
     dkWeaver: 'https://dkw.dev.cloudnativedays.jp',
+    loki: 'https://stg.loki.cloudnativedays.jp',
   },
   imageTags: {
     dreamkast_ecs: '61c072293671ceddc181bd1b129e4a246c8efe3c',

--- a/ecspresso/stg/dreamkast/task-def.jsonnet
+++ b/ecspresso/stg/dreamkast/task-def.jsonnet
@@ -9,6 +9,7 @@ dreamkast.taskDef(
   region=const.region,
   dkApiEndpoint=const.externalEndpoints.dkApi,
   dkWeaverEndpoint=const.externalEndpoints.dkWeaver,
+  lokiEndpoint=const.externalEndpoints.loki,
   rdbInternalEndpoint=const.internalEndpoints.rdb,
   redisInternalEndpoint=const.internalEndpoints.redis,
 

--- a/ecspresso/stg/dreamkast/task-def.jsonnet
+++ b/ecspresso/stg/dreamkast/task-def.jsonnet
@@ -23,6 +23,7 @@ dreamkast.taskDef(
   railsAppSecretManagerName=const.secretManager.railsApp,
   rdsSecretManagerName=const.secretManager.rds,
   dreamkastSecretManagerName=const.secretManager.dk,
+  mackerelSecretManagerName=const.secretManager.mackerel,
 
   enableLogging=true,
 )


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->

```
$ jsonnet ./ecspresso/stg/dreamkast/task-def.jsonnet
```

<details>

<summary>task-def.json</summary>

```json
{
   "containerDefinitions": [
      {
         "command": [
            "bundle exec rails db:migrate; bundle exec rails db:seed;"
         ],
         "cpu": 64,
         "dependsOn": [
            {
               "condition": "HEALTHY",
               "containerName": "log_router"
            }
         ],
         "entryPoint": [
            "/bin/bash",
            "-c"
         ],
         "environment": [
            {
               "name": "RAILS_ENV",
               "value": "production"
            },
            {
               "name": "MYSQL_HOST",
               "value": "dreamkast-stg-rds.cctlaulyxvbk.us-west-2.rds.amazonaws.com"
            },
            {
               "name": "MYSQL_DATABASE",
               "value": "dreamkast"
            },
            {
               "name": "REDIS_URL",
               "value": "redis://redis.staging.local"
            },
            {
               "name": "SENTRY_DSN",
               "value": "TODO"
            },
            {
               "name": "S3_BUCKET",
               "value": "dreamkast-stg-bucket"
            },
            {
               "name": "S3_REGION",
               "value": "us-west-2"
            },
            {
               "name": "DREAMKAST_NAMESPACE",
               "value": "dreamkast-stg-dk"
            }
         ],
         "essential": false,
         "image": "607167088920.dkr.ecr.us-west-2.amazonaws.com/dreamkast-ecs:61c072293671ceddc181bd1b129e4a246c8efe3c",
         "links": [ ],
         "logConfiguration": {
            "logDriver": "awsfirelens",
            "options": {
               "LabelKeys": "container_name,ecs_task_definition,source,ecs_cluster",
               "Labels": "{job=\"dreamkast-stg-dk\"}",
               "LineFormat": "key_value",
               "Name": "grafana-loki",
               "RemoveKeys": "container_id,ecs_task_arn",
               "Url": "https://stg.loki.cloudnativedays.jp/loki/api/v1/push"
            }
         },
         "memoryReservation": 128,
         "mountPoints": [ ],
         "name": "initdb",
         "portMappings": [ ],
         "secrets": [
            {
               "name": "RAILS_MASTER_KEY",
               "valueFrom": "arn:aws:secretsmanager:us-west-2:607167088920:secret:dreamkast/rails-app-secret-SqidNC"
            },
            {
               "name": "AUTH0_CLIENT_ID",
               "valueFrom": "arn:aws:secretsmanager:us-west-2:607167088920:secret:dreamkast/staging-env-SID4P1:AUTH0_CLIENT_ID::"
            },
            {
               "name": "AUTH0_CLIENT_SECRET",
               "valueFrom": "arn:aws:secretsmanager:us-west-2:607167088920:secret:dreamkast/staging-env-SID4P1:AUTH0_CLIENT_SECRET::"
            },
            {
               "name": "AUTH0_DOMAIN",
               "valueFrom": "arn:aws:secretsmanager:us-west-2:607167088920:secret:dreamkast/staging-env-SID4P1:AUTH0_DOMAIN::"
            },
            {
               "name": "MYSQL_USER",
               "valueFrom": "arn:aws:secretsmanager:us-west-2:607167088920:secret:dreamkast-stg-rds-secret-0dsVhM:username::"
            },
            {
               "name": "MYSQL_PASSWORD",
               "valueFrom": "arn:aws:secretsmanager:us-west-2:607167088920:secret:dreamkast-stg-rds-secret-0dsVhM:password::"
            }
         ],
         "volumesFrom": [ ]
      },
      {
         "command": [ ],
         "cpu": 448,
         "dependsOn": [
            {
               "condition": "SUCCESS",
               "containerName": "initdb"
            }
         ],
         "entryPoint": [ ],
         "environment": [
            {
               "name": "RAILS_ENV",
               "value": "production"
            },
            {
               "name": "MYSQL_HOST",
               "value": "dreamkast-stg-rds.cctlaulyxvbk.us-west-2.rds.amazonaws.com"
            },
            {
               "name": "MYSQL_DATABASE",
               "value": "dreamkast"
            },
            {
               "name": "REDIS_URL",
               "value": "redis://redis.staging.local"
            },
            {
               "name": "SENTRY_DSN",
               "value": "TODO"
            },
            {
               "name": "S3_BUCKET",
               "value": "dreamkast-stg-bucket"
            },
            {
               "name": "S3_REGION",
               "value": "us-west-2"
            },
            {
               "name": "DREAMKAST_NAMESPACE",
               "value": "dreamkast-stg-dk"
            },
            {
               "name": "OTEL_SERVICE_NAME",
               "value": "dreamkast"
            },
            {
               "name": "AWS_REGION",
               "value": "us-west-2"
            },
            {
               "name": "SQS_FIFO_QUEUE_URL",
               "value": "https://sqs.us-west-2.amazonaws.com/607167088920/dreamkast-stg-fifo-queue.fifo"
            },
            {
               "name": "DREAMKAST_API_ADDR",
               "value": "https://api.stg.cloudnativedays.jp"
            },
            {
               "name": "DREAMKAST_WEAVER_ADDR",
               "value": "https://dkw.dev.cloudnativedays.jp"
            },
            {
               "name": "DREAMKAST_UI_BASE_URL",
               "value": "*"
            }
         ],
         "essential": true,
         "image": "607167088920.dkr.ecr.us-west-2.amazonaws.com/dreamkast-ecs:61c072293671ceddc181bd1b129e4a246c8efe3c",
         "links": [ ],
         "logConfiguration": {
            "logDriver": "awsfirelens",
            "options": {
               "LabelKeys": "container_name,ecs_task_definition,source,ecs_cluster",
               "Labels": "{job=\"dreamkast-stg-dk\"}",
               "LineFormat": "key_value",
               "Name": "grafana-loki",
               "RemoveKeys": "container_id,ecs_task_arn",
               "Url": "https://stg.loki.cloudnativedays.jp/loki/api/v1/push"
            }
         },
         "memoryReservation": 896,
         "mountPoints": [ ],
         "name": "dreamkast",
         "portMappings": [
            {
               "containerPort": 3000,
               "hostPort": 3000,
               "protocol": "tcp"
            }
         ],
         "secrets": [
            {
               "name": "RAILS_MASTER_KEY",
               "valueFrom": "arn:aws:secretsmanager:us-west-2:607167088920:secret:dreamkast/rails-app-secret-SqidNC"
            },
            {
               "name": "AUTH0_CLIENT_ID",
               "valueFrom": "arn:aws:secretsmanager:us-west-2:607167088920:secret:dreamkast/staging-env-SID4P1:AUTH0_CLIENT_ID::"
            },
            {
               "name": "AUTH0_CLIENT_SECRET",
               "valueFrom": "arn:aws:secretsmanager:us-west-2:607167088920:secret:dreamkast/staging-env-SID4P1:AUTH0_CLIENT_SECRET::"
            },
            {
               "name": "AUTH0_DOMAIN",
               "valueFrom": "arn:aws:secretsmanager:us-west-2:607167088920:secret:dreamkast/staging-env-SID4P1:AUTH0_DOMAIN::"
            },
            {
               "name": "MYSQL_USER",
               "valueFrom": "arn:aws:secretsmanager:us-west-2:607167088920:secret:dreamkast-stg-rds-secret-0dsVhM:username::"
            },
            {
               "name": "MYSQL_PASSWORD",
               "valueFrom": "arn:aws:secretsmanager:us-west-2:607167088920:secret:dreamkast-stg-rds-secret-0dsVhM:password::"
            }
         ],
         "volumesFrom": [ ]
      },
      {
         "command": [ ],
         "cpu": 0,
         "dependsOn": [ ],
         "entryPoint": [ ],
         "environment": [ ],
         "essential": false,
         "firelensConfiguration": {
            "options": {
               "enable-ecs-log-metadata": "true"
            },
            "type": "fluentbit"
         },
         "image": "grafana/fluent-bit-plugin-loki:2.9.10",
         "links": [ ],
         "logConfiguration": {
            "logDriver": "awslogs",
            "options": {
               "awslogs-create-group": "true",
               "awslogs-group": "dreamkast-stg-dk",
               "awslogs-region": "us-west-2",
               "awslogs-stream-prefix": "firelens"
            }
         },
         "memoryReservation": 50,
         "mountPoints": [ ],
         "name": "log_router",
         "portMappings": [ ],
         "secrets": [ ],
         "volumesFrom": [ ]
      },
      {
         "command": [ ],
         "cpu": 0,
         "dependsOn": [ ],
         "entryPoint": [ ],
         "environment": [
            {
               "name": "MACKEREL_CONTAINER_PLATFORM",
               "value": "ecs"
            }
         ],
         "essential": false,
         "image": "mackerel/mackerel-container-agent:latest",
         "links": [ ],
         "logConfiguration": {
            "logDriver": "awslogs",
            "options": {
               "awslogs-create-group": "true",
               "awslogs-group": "dreamkast-stg-dk",
               "awslogs-region": "us-west-2",
               "awslogs-stream-prefix": "mackerel-agent"
            }
         },
         "memoryReservation": 128,
         "mountPoints": [ ],
         "name": "mackerel-container-agent",
         "portMappings": [ ],
         "secrets": [
            {
               "name": "MACKEREL_CONTAINER_PLATFORM",
               "valueFrom": "arn:aws:secretsmanager:us-west-2:607167088920:secret:observability/mackerel/api-key-tjOHnb"
            }
         ],
         "volumesFrom": [ ]
      }
   ],
   "cpu": "512",
   "executionRoleArn": "arn:aws:iam::607167088920:role/dreamkast-dev-ecs-task-execution-role",
   "family": "dreamkast-stg-dk",
   "memory": "1024",
   "networkMode": "awsvpc",
   "requiresCompatibilities": [
      "FARGATE"
   ],
   "taskRoleArn": "arn:aws:iam::607167088920:role/dreamkast-dev-ecs-dreamkast",
   "volumes": [ ]
}
```

</details>
