### PR TITLE
DKのReviewApp環境が残る問題の対処

### DIFF
--- a/ecspresso/reviewapps/dk-2484/cleanup.sh
+++ b/ecspresso/reviewapps/dk-2484/cleanup.sh
@@ -4,6 +4,7 @@ cd $(dirname $0)
 
 find . -name "ecspresso.jsonnet" | xargs -I{} -P10 ecspresso --config={} delete --force --terminate ||:
 sleep 10 # wait for ECS Services to be deleted
+aws events remove-targets --rule dk-2484-harvestjob --ids dk-2484-harvestjob
 aws events describe-rule --name dk-2484-harvestjob &&   aws events delete-rule --name dk-2484-harvestjob --force
 aws ecs describe-task-definition --task-definition dreamkast-dev-dk-2484-harvestjob &&   aws ecs deregister-task-definition --task-definition dreamkast-dev-dk-2484-harvestjob
 aws servicediscovery get-service --id srv-ub3hk6x3rba2ipxb &&   aws servicediscovery delete-service --id srv-ub3hk6x3rba2ipxb

--- a/ecspresso/reviewapps/dk-2486/cleanup.sh
+++ b/ecspresso/reviewapps/dk-2486/cleanup.sh
@@ -4,6 +4,7 @@ cd $(dirname $0)
 
 find . -name "ecspresso.jsonnet" | xargs -I{} -P10 ecspresso --config={} delete --force --terminate ||:
 sleep 10 # wait for ECS Services to be deleted
+aws events remove-targets --rule dk-2486-harvestjob --ids dk-2486-harvestjob
 aws events describe-rule --name dk-2486-harvestjob &&   aws events delete-rule --name dk-2486-harvestjob --force
 aws ecs describe-task-definition --task-definition dreamkast-dev-dk-2486-harvestjob &&   aws ecs deregister-task-definition --task-definition dreamkast-dev-dk-2486-harvestjob
 aws servicediscovery get-service --id srv-tt7ltwz53ycyuaf4 &&   aws servicediscovery delete-service --id srv-tt7ltwz53ycyuaf4

--- a/ecspresso/reviewapps/dk-2487/cleanup.sh
+++ b/ecspresso/reviewapps/dk-2487/cleanup.sh
@@ -4,6 +4,7 @@ cd $(dirname $0)
 
 find . -name "ecspresso.jsonnet" | xargs -I{} -P10 ecspresso --config={} delete --force --terminate ||:
 sleep 10 # wait for ECS Services to be deleted
+aws events remove-targets --rule dk-2487-harvestjob --ids dk-2487-harvestjob
 aws events describe-rule --name dk-2487-harvestjob &&   aws events delete-rule --name dk-2487-harvestjob --force
 aws ecs describe-task-definition --task-definition dreamkast-dev-dk-2487-harvestjob &&   aws ecs deregister-task-definition --task-definition dreamkast-dev-dk-2487-harvestjob
 aws servicediscovery get-service --id srv-mim5vhv7bpntae6i &&   aws servicediscovery delete-service --id srv-mim5vhv7bpntae6i

--- a/ecspresso/reviewapps/dk-2489/cleanup.sh
+++ b/ecspresso/reviewapps/dk-2489/cleanup.sh
@@ -4,6 +4,7 @@ cd $(dirname $0)
 
 find . -name "ecspresso.jsonnet" | xargs -I{} -P10 ecspresso --config={} delete --force --terminate ||:
 sleep 10 # wait for ECS Services to be deleted
+aws events remove-targets --rule dk-2489-harvestjob --ids dk-2489-harvestjob
 aws events describe-rule --name dk-2489-harvestjob &&   aws events delete-rule --name dk-2489-harvestjob --force
 aws ecs describe-task-definition --task-definition dreamkast-dev-dk-2489-harvestjob &&   aws ecs deregister-task-definition --task-definition dreamkast-dev-dk-2489-harvestjob
 aws servicediscovery get-service --id srv-2to5kjfuxszmtiwb &&   aws servicediscovery delete-service --id srv-2to5kjfuxszmtiwb

--- a/ecspresso/reviewapps/template-dk/initialize.sh
+++ b/ecspresso/reviewapps/template-dk/initialize.sh
@@ -80,6 +80,7 @@ cd \$(dirname \$0)
 find . -name "ecspresso.jsonnet" | xargs -I{} -P10 ecspresso --config={} delete --force --terminate ||:
 sleep 10 # wait for ECS Services to be deleted
 aws events describe-rule --name ${PR_NAME}-harvestjob && \
+  aws events remove-targets --rule ${PR_NAME}-harvestjob --ids ${PR_NAME}-harvestjob \
   aws events delete-rule --name ${PR_NAME}-harvestjob --force
 aws ecs describe-task-definition --task-definition dreamkast-dev-${PR_NAME}-harvestjob && \
   aws ecs deregister-task-definition --task-definition dreamkast-dev-${PR_NAME}-harvestjob


### PR DESCRIPTION
# Summary

- DKのReviewApp環境が残る問題の対処を入れました
  - see: https://www.notion.so/pfem/2025-02-23-1a321b0141e080ad8425fcb490cee847?pvs=4#1a321b0141e0808ab100d467f5777792
- 事象
  - DKのReviewApp環境ではTargetが設定されたEventBridgeが作成される
    - https://us-west-2.console.aws.amazon.com/events/home?region=us-west-2#/eventbus/default/rules/dk-2490-harvestjob
  - [creanup script](https://github.com/cloudnativedaysjp/dreamkast-infra/blob/main/ecspresso/reviewapps/dk-2489/cleanup.sh#L7)でEventBridgeの削除を試みているが、Targetが付与されているため、削除できないエラーが発生
    - https://github.com/cloudnativedaysjp/dreamkast/actions/runs/13453103343/job/37591157532
    - その結果、ReviewApp環境のコード削除にたどり着くことなく終了し、環境が残り続ける
- 対処
  - Targeを削除する一文を書いた
  - creanup.shはinitialize.shで生成しているので、そちらにも一文書いた
 



