### PR TITLE
update warm-up action

### DIFF
--- a/.github/workflows/warm-up.yml
+++ b/.github/workflows/warm-up.yml
@@ -11,8 +11,7 @@ env:
 jobs:
   auto_warm_up:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    permissions: {}
     timeout-minutes: 10
 
     steps:
@@ -87,19 +86,8 @@ jobs:
         with:
           repository: cloudnativedaysjp/dreamkast-infra
           branch: main
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           commit_message: |
             Auto-update replicas for conference day
-
-      - name: Trigger ecspresso workflow
-        if: steps.check-diff.outputs.changes == 'true'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            github.rest.repos.createDispatchEvent({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              event_type: 'trigger-ecspresso'
-            })
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # to trigger other Actions by this push
+          app_id: ${{secrets.APP_ID}}
+          app_private_key: ${{secrets.APP_PRIVATE_KEY}}


### PR DESCRIPTION
* push commits by GitHubApp instead of using workflow-trigger
    * because deploy action triggered by workflow-trigger pull old commits sometimes.