### PR TITLE
dreamkast-otelcolコンテナは最新のtagを参照する

### DIFF
--- a/ecspresso/base/dreamkast.libsonnet
+++ b/ecspresso/base/dreamkast.libsonnet
@@ -362,7 +362,7 @@ local util = import './util.libsonnet';
         assert mackerelSecretManagerName != '';
         root.containerDefinitionCommon {
           name: 'otelcol',
-          image: '%s.dkr.ecr.%s.amazonaws.com/dreamkast-otelcol:%s' % [const.accountID, region, imageTag],
+          image: '%s.dkr.ecr.%s.amazonaws.com/dreamkast-otelcol:branch-main' % [const.accountID, region],
           cpu: const.otelcolSidecarResources.cpu,
           memory: const.otelcolSidecarResources.memory,
           memoryReservation: const.otelcolSidecarResources.memoryReservation,


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # None

stgのdreamkastが以下のようなエラーを吐きタスクの起動に失敗し続けている。
```
CannotPullContainerError: pull image manifest has been retried 1 time(s): failed to resolve ref [607167088920.dkr.ecr.us-west-2.amazonaws.com/dreamkast-otelcol:main-7e3e1f8805628b477b671f9a960b3cf989d0bf10](http://607167088920.dkr.ecr.us-west-2.amazonaws.com/dreamkast-otelcol:main-7e3e1f8805628b477b671f9a960b3cf989d0bf10): [607167088920.dkr.ecr.us-west-2.amazonaws.com/dreamkast-otelcol:main-7e3e1f8805628b477b671f9a960b3cf989d0bf10](http://607167088920.dkr.ecr.us-west-2.amazonaws.com/dreamkast-otelcol:main-7e3e1f8805628b477b671f9a960b3cf989d0bf10): not found
```
このタグのコンテナイメージがECRに無いからである。上記の `main-7e3e1f8805628b477b671f9a960b3cf989d0bf10` はdreamkast-ecsコンテナのイメージタグであり、間違っている。dreamkast-otelcolコンテナのイメージタグを指定せねばならない。
常に最新のdreamkast-otelcolコンテナを使うように設定する。

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
