### PR TITLE
the logging exporter has been deprecated, use the debug exporter instead

### DIFF
--- a/ecspresso/prod/dreamkast/files/otelcol-config.yaml
+++ b/ecspresso/prod/dreamkast/files/otelcol-config.yaml
@@ -19,8 +19,6 @@ receivers:
       memory:
       network:
       paging:
-  logging:
-    log_level: info
 
 processors:
   attributes/app:
@@ -47,8 +45,6 @@ exporters:
     compression: gzip
     headers:
       Mackerel-Api-Key: ${env:MACKEREL_APIKEY}
-  logging:
-    log_level: debug
 
 service:
   pipelines:

--- a/ecspresso/stg/dreamkast/files/otelcol-config.yaml
+++ b/ecspresso/stg/dreamkast/files/otelcol-config.yaml
@@ -19,8 +19,6 @@ receivers:
       memory:
       network:
       paging:
-  logging:
-    log_level: info
 
 processors:
   attributes/app:
@@ -47,8 +45,6 @@ exporters:
     compression: gzip
     headers:
       Mackerel-Api-Key: ${env:MACKEREL_APIKEY}
-  logging:
-    log_level: debug
 
 service:
   pipelines:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

dreamkastサービスのotelcolコンテナがexit 1で落ちている。

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

再現させる : 

```console
% OTELCOL_CONFIG="$(cat ~/dev/cloudnativedays/dreamkast-infra/ecspresso/stg/dreamkast/files/otelcol-config.yaml)" docker compose up
[+] Running 1/1
 ✔ Container dreamkast-otelcol-otelcol-dreamkast-1  Recreated                                                                                                                                                                                    0.0s 
Attaching to otelcol-dreamkast-1
otelcol-dreamkast-1  | Error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):
otelcol-dreamkast-1  | 
otelcol-dreamkast-1  | 'receivers' the logging exporter has been deprecated, use the debug exporter instead
otelcol-dreamkast-1  | 'exporters' the logging exporter has been deprecated, use the debug exporter instead
otelcol-dreamkast-1  | 2025/07/21 14:58:29 collector server run finished with error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):
otelcol-dreamkast-1  | 
otelcol-dreamkast-1  | 'receivers' the logging exporter has been deprecated, use the debug exporter instead
otelcol-dreamkast-1  | 'exporters' the logging exporter has been deprecated, use the debug exporter instead
otelcol-dreamkast-1 exited with code 1
```

この差分を当てると : 

```console
% OTELCOL_CONFIG="$(cat ~/dev/cloudnativedays/dreamkast-infra/ecspresso/stg/dreamkast/files/otelcol-config.yaml)" docker compose up
[+] Running 1/1
 ✔ Container dreamkast-otelcol-otelcol-dreamkast-1  Recreated                                                                                                                                                                                    0.0s 
Attaching to otelcol-dreamkast-1
otelcol-dreamkast-1  | 2025-07-21T15:02:15.455Z	info	service@v0.130.0/service.go:197	Setting up own telemetry...	{"resource": {"service.instance.id": "3e887540-881c-4ade-af1d-756b7a9a67df", "service.name": "otelcol", "service.version": ""}}
otelcol-dreamkast-1  | 2025-07-21T15:02:15.456Z	warn	filesystemscraper/factory.go:48	No `root_path` config set when running in docker environment, will report container filesystem stats. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only	{"resource": {"service.instance.id": "3e887540-881c-4ade-af1d-756b7a9a67df", "service.name": "otelcol", "service.version": ""}, "otelcol.component.id": "hostmetrics", "otelcol.component.kind": "receiver", "otelcol.signal": "metrics"}
otelcol-dreamkast-1  | 2025-07-21T15:02:15.457Z	info	service@v0.130.0/service.go:257	Starting otelcol...	{"resource": {"service.instance.id": "3e887540-881c-4ade-af1d-756b7a9a67df", "service.name": "otelcol", "service.version": ""}, "Version": "", "NumCPU": 2}
otelcol-dreamkast-1  | 2025-07-21T15:02:15.457Z	info	extensions/extensions.go:41	Starting extensions...	{"resource": {"service.instance.id": "3e887540-881c-4ade-af1d-756b7a9a67df", "service.name": "otelcol", "service.version": ""}}
otelcol-dreamkast-1  | 2025-07-21T15:02:15.457Z	info	extensions/extensions.go:45	Extension is starting...	{"resource": {"service.instance.id": "3e887540-881c-4ade-af1d-756b7a9a67df", "service.name": "otelcol", "service.version": ""}, "otelcol.component.id": "health_check", "otelcol.component.kind": "extension"}
otelcol-dreamkast-1  | 2025-07-21T15:02:15.458Z	info	healthcheckextension@v0.130.0/healthcheckextension.go:32	Starting health_check extension	{"resource": {"service.instance.id": "3e887540-881c-4ade-af1d-756b7a9a67df", "service.name": "otelcol", "service.version": ""}, "otelcol.component.id": "health_check", "otelcol.component.kind": "extension", "config": {"Endpoint":"localhost:13133","TLS":{},"CORS":{},"Auth":{},"MaxRequestBodySize":0,"IncludeMetadata":false,"ResponseHeaders":null,"CompressionAlgorithms":null,"ReadTimeout":0,"ReadHeaderTimeout":0,"WriteTimeout":0,"IdleTimeout":0,"Middlewares":null,"Path":"/","ResponseBody":null,"CheckCollectorPipeline":{"Enabled":false,"Interval":"5m","ExporterFailureThreshold":5}}}
otelcol-dreamkast-1  | 2025-07-21T15:02:15.458Z	info	extensions/extensions.go:62	Extension started.	{"resource": {"service.instance.id": "3e887540-881c-4ade-af1d-756b7a9a67df", "service.name": "otelcol", "service.version": ""}, "otelcol.component.id": "health_check", "otelcol.component.kind": "extension"}
otelcol-dreamkast-1  | 2025-07-21T15:02:15.458Z	info	otlpreceiver@v0.130.0/otlp.go:117	Starting GRPC server	{"resource": {"service.instance.id": "3e887540-881c-4ade-af1d-756b7a9a67df", "service.name": "otelcol", "service.version": ""}, "otelcol.component.id": "otlp", "otelcol.component.kind": "receiver", "otelcol.signal": "traces", "endpoint": "0.0.0.0:4317"}
otelcol-dreamkast-1  | 2025-07-21T15:02:15.459Z	info	otlpreceiver@v0.130.0/otlp.go:175	Starting HTTP server	{"resource": {"service.instance.id": "3e887540-881c-4ade-af1d-756b7a9a67df", "service.name": "otelcol", "service.version": ""}, "otelcol.component.id": "otlp", "otelcol.component.kind": "receiver", "otelcol.signal": "traces", "endpoint": "0.0.0.0:4318"}
otelcol-dreamkast-1  | 2025-07-21T15:02:15.459Z	info	internal/resourcedetection.go:137	began detecting resource information	{"resource": {"service.instance.id": "3e887540-881c-4ade-af1d-756b7a9a67df", "service.name": "otelcol", "service.version": ""}, "otelcol.component.id": "resourcedetection/app", "otelcol.component.kind": "processor", "otelcol.pipeline.id": "metrics/app", "otelcol.signal": "metrics"}
otelcol-dreamkast-1  | 2025-07-21T15:02:15.459Z	info	internal/resourcedetection.go:188	detected resource information	{"resource": {"service.instance.id": "3e887540-881c-4ade-af1d-756b7a9a67df", "service.name": "otelcol", "service.version": ""}, "otelcol.component.id": "resourcedetection/app", "otelcol.component.kind": "processor", "otelcol.pipeline.id": "metrics/app", "otelcol.signal": "metrics", "resource": {}}
otelcol-dreamkast-1  | 2025-07-21T15:02:15.460Z	info	healthcheck/handler.go:132	Health Check state change	{"resource": {"service.instance.id": "3e887540-881c-4ade-af1d-756b7a9a67df", "service.name": "otelcol", "service.version": ""}, "otelcol.component.id": "health_check", "otelcol.component.kind": "extension", "status": "ready"}
otelcol-dreamkast-1  | 2025-07-21T15:02:15.460Z	info	service@v0.130.0/service.go:280	Everything is ready. Begin running and processing data.	{"resource": {"service.instance.id": "3e887540-881c-4ade-af1d-756b7a9a67df", "service.name": "otelcol", "service.version": ""}}

```

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
