### PR TITLE
主たるコンテナのCPU利用量を特別には制限しない

### DIFF
--- a/ecspresso/base/dreamkast-fifo-worker.libsonnet
+++ b/ecspresso/base/dreamkast-fifo-worker.libsonnet
@@ -57,7 +57,6 @@ local const = import './const.libsonnet';
         image: '%s.dkr.ecr.%s.amazonaws.com/dreamkast-ecs:%s' % [const.accountID, region, imageTag],
         entryPoint: ['bundle'],
         command: ['exec', 'rake', 'aws_sqs:fifo_job'],
-        cpu: cpu,
         memory: memory,
         memoryReservation: memory,
         essential: true,

--- a/ecspresso/base/dreamkast-ui.libsonnet
+++ b/ecspresso/base/dreamkast-ui.libsonnet
@@ -101,7 +101,6 @@ local const = import './const.libsonnet';
           },
         ],
         essential: true,
-        cpu: cpu,
         memory: memory,
         memoryReservation: memory,
         portMappings: [

--- a/ecspresso/base/dreamkast-weaver.libsonnet
+++ b/ecspresso/base/dreamkast-weaver.libsonnet
@@ -55,7 +55,6 @@ local const = import './const.libsonnet';
       command: [],
       restartPolicy: { enabled: true },
 
-      cpu: error 'must be overridden',
       memory: error 'must be overridden',
       essential: false,
 
@@ -136,7 +135,6 @@ local const = import './const.libsonnet';
         name: 'dkw-serve',
         entryPoint: ['/dkw', 'serve'],
         command: ['--port=8080'],
-        cpu: cpu,
         memory: memory,
         memoryReservation: memory,
         essential: true,


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

背景 : 
https://github.com/cloudnativedaysjp/dreamkast-infra/pull/4709 でOpentelemetry collectorのCPU利用を設定し、https://github.com/cloudnativedaysjp/dreamkast-infra/pull/4713 で有効に設定した。その結果、主たるコンテナがタスクのCPUを全量使い更にcollectorが自分のCPUを要求する事態に陥り、https://github.com/cloudnativedaysjp/dreamkast-infra/actions/runs/17953283448/job/51058172844 のようにデプロイが失敗している。

>Error: 25-09-23T16:54:28.851Z [ERROR] FAILED. failed to register task definition: operation error ECS: RegisterTaskDefinition, https response error StatusCode: 400, RequestID: 0c5892f7-f5be-469c-8ba9-b8e48df9ac82, ClientException: The sum of all container 'cpu' values cannot be greater than the value of the task 'cpu'.

提案 : 
主たるコンテナは、サイドカーコンテナに割り振られなかったCPUを全量使ってよいはずであり、特別に制限を設けなくてもよいのではないか。

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
