### PR TITLE
or_sub_policyを使わず、ポリシーを並べてorを表現する

### DIFF
--- a/ecspresso/prod/dreamkast/files/otelcol-config.yaml
+++ b/ecspresso/prod/dreamkast/files/otelcol-config.yaml
@@ -40,22 +40,18 @@ processors:
     override: false
   tail_sampling:
     policies:
-      - name: include http 5xx
-        type: or
-        or:
-          or_sub_policy:
-            - name: http response status
-              type: numeric_attribute
-              numeric_attribute:
-                key: http.response.status_code
-                min_value: 500
-                max_value: 599
-            - name: http status
-              type: numeric_attribute
-              numeric_attribute:
-                key: http.status_code
-                min_value: 500
-                max_value: 599
+      - name: include http 5xx response status
+        type: numeric_attribute
+        numeric_attribute:
+          key: http.response.status_code
+          min_value: 500
+          max_value: 599
+      - name: include http 5xx status
+        type: numeric_attribute
+        numeric_attribute:
+          key: http.status_code  # dreamkastはこの古い仕様で送っている
+          min_value: 500
+          max_value: 599
       - name: include slow http
         type: latency
         latency:

--- a/ecspresso/stg/dreamkast/files/otelcol-config.yaml
+++ b/ecspresso/stg/dreamkast/files/otelcol-config.yaml
@@ -40,22 +40,18 @@ processors:
     override: false
   tail_sampling:
     policies:
-      - name: include http 5xx
-        type: or
-        or:
-          or_sub_policy:
-            - name: http response status
-              type: numeric_attribute
-              numeric_attribute:
-                key: http.response.status_code
-                min_value: 500
-                max_value: 599
-            - name: http status
-              type: numeric_attribute
-              numeric_attribute:
-                key: http.status_code
-                min_value: 500
-                max_value: 599
+      - name: include http 5xx response status
+        type: numeric_attribute
+        numeric_attribute:
+          key: http.response.status_code
+          min_value: 500
+          max_value: 599
+      - name: include http 5xx status
+        type: numeric_attribute
+        numeric_attribute:
+          key: http.status_code  # dreamkastはこの古い仕様で送っている
+          min_value: 500
+          max_value: 599
       - name: include slow http
         type: latency
         latency:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

stgのotelcolで以下のエラーが起こりotelcolが起動しない。

```
2025-11-06T11:42:52.629Z	error	tailsamplingprocessor@v0.138.0/processor.go:642	Failed to load initial sampling policy	{"resource": {"service.instance.id": "e0be7db0-5811-46cd-8edc-ee78327bf9e9", "service.name": "otelcol", "service.version": ""}, "otelcol.component.id": "tail_sampling", "otelcol.component.kind": "processor", "otelcol.pipeline.id": "traces", "otelcol.signal": "traces", "error": "failed to create policy evaluator for \"include http 5xx\": unknown sampling policy type or"}
```

or_sub_policyを使わず、ポリシーを並べてorを表現する

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
