### PR TITLE
fix: remove container health check from sgtm task definition

### DIFF
--- a/ecspresso/base/sgtm.libsonnet
+++ b/ecspresso/base/sgtm.libsonnet
@@ -70,13 +70,6 @@ local const = import './const.libsonnet';
           hostPort: 8080,
           protocol: 'tcp',
         }],
-        healthCheck: {
-          command: ['CMD-SHELL', 'curl -f http://localhost:8080/healthz || exit 1'],
-          interval: 30,
-          timeout: 5,
-          retries: 3,
-          startPeriod: 60,
-        },
       } + if enableLogging then {
         logConfiguration: {
           logDriver: 'awslogs',


### PR DESCRIPTION
sGTM image is distroless and has no shell or curl, causing CMD-SHELL health check to always fail. ALB health check on /healthz is sufficient.

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #5237 5237

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Document update or simple typo fix
- [ ] Maintenance/update components
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I have checked backward/forward compatibility that may cause regarding this change.

<!-- # Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->
