### PR TITLE
add Loki logging to dreamkast-fifo-worker on prod

### DIFF
--- a/ecspresso/prod/dreamkast-fifo-worker/task-def.jsonnet
+++ b/ecspresso/prod/dreamkast-fifo-worker/task-def.jsonnet
@@ -23,7 +23,10 @@ dreamkast_fifo_worker.taskDef(
   rdsSecretManagerName=const.secretManager.rds,
   dreamkastSecretManagerName=const.secretManager.dk,
 
-  enableLogging=true,
+  enableLogging=false,
+
+  enableLokiLogging=true,
+  lokiEndpoint=const.externalEndpoints.loki,
 
   enableOtelcolSidecar=false,
   mackerelSecretManagerName=const.secretManager.mackerel,


### PR DESCRIPTION
## Summary

- prod の dreamkast-fifo-worker で `enableLogging=false` → Loki ロギング (`enableLokiLogging=true`) に切り替え
- AWS FireLens + Fluent Bit (`grafana/fluent-bit-plugin-loki:2.9.10`) 経由で `https://loki.cloudnativedays.jp` にログを送信

## Test plan

- [x] `ecspresso render task-definition` でビルド成功を確認済み