### PR TITLE
Split ecspresso deploy workflow per environment

### DIFF
--- a/.github/workflows/ecspresso-preview.yml
+++ b/.github/workflows/ecspresso-preview.yml
@@ -6,8 +6,7 @@ on:
     paths:
       - 'ecspresso/**'
 
-# this workflow should be processed by FIFO
-concurrency: ecspresso
+concurrency: ecspresso-preview
 
 jobs:
   preview:

--- a/.github/workflows/ecspresso-prod.yml
+++ b/.github/workflows/ecspresso-prod.yml
@@ -1,13 +1,16 @@
-name: ecspresso deploy
+name: ecspresso deploy (prod)
 
 on:
   push:
     branches: ["main"]
+    paths:
+      - 'ecspresso/prod/**'
+      - 'ecspresso/base/**'
+      - '.github/workflows/ecspresso-prod.yml'
   repository_dispatch:
     types: [trigger-ecspresso]
 
-# this workflow should be processed by FIFO
-concurrency: ecspresso
+concurrency: ecspresso-prod
 
 permissions:
   contents: read
@@ -15,12 +18,6 @@ permissions:
 
 jobs:
   ecspresso:
-    strategy:
-      matrix:
-        environment:
-        - prod
-        - stg
-        - reviewapps
     runs-on: "ubuntu-latest"
     permissions:
       contents: read
@@ -46,14 +43,14 @@ jobs:
       # ecschedule
       #
       - name: register taskdef for ecschedule
-        working-directory: "ecspresso/${{matrix.environment}}"
+        working-directory: "ecspresso/prod"
         run: |
           # shellcheck disable=SC2016
           find . -name "ecspresso.taskdef.jsonnet" | grep -vE "^./template" \
             | xargs -I{} -P10 bash -c \
             '[ "$(ecspresso --config={} diff)" = "" ] || ecspresso --config={} register'
       - name: ecschedule apply
-        working-directory: "ecspresso/${{matrix.environment}}"
+        working-directory: "ecspresso/prod"
         run: |
           find . -name "ecschedule.jsonnet" | grep -vE "^./template" \
             | xargs -I{} -P10 bash -c \
@@ -63,10 +60,9 @@ jobs:
       # ecspresso
       #
       - name: run ecspresso
-        working-directory: "ecspresso/${{matrix.environment}}"
+        working-directory: "ecspresso/prod"
         run: |
           # shellcheck disable=SC2016
           find . -name "ecspresso.jsonnet" | grep -vE "^./template" \
             | xargs -I{} -P10 bash -c \
             '[ "$(ecspresso --config={} diff)" = "" ] || ecspresso --config={} deploy'
-

--- a/.github/workflows/ecspresso-reviewapps.yml
+++ b/.github/workflows/ecspresso-reviewapps.yml
@@ -1,0 +1,68 @@
+name: ecspresso deploy (reviewapps)
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - 'ecspresso/reviewapps/**'
+      - 'ecspresso/base/**'
+      - '.github/workflows/ecspresso-reviewapps.yml'
+  repository_dispatch:
+    types: [trigger-ecspresso]
+
+concurrency: ecspresso-reviewapps
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  ecspresso:
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+      id-token: write
+    timeout-minutes: 30
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
+        with:
+          aws-region: ap-northeast-1
+          role-to-assume: "arn:aws:iam::607167088920:role/github-actions-dreamkast"
+
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Install ecspresso
+        uses: kayac/ecspresso@e048f284f6b81b4f99085a963838c762be99361c # v2
+      - name: Install ecschedule
+        uses: Songmu/ecschedule@5fcc5e5b08af78d797c2b9e94b6f9a8ff9f7b626 # v0.15.3
+
+      #
+      # ecschedule
+      #
+      - name: register taskdef for ecschedule
+        working-directory: "ecspresso/reviewapps"
+        run: |
+          # shellcheck disable=SC2016
+          find . -name "ecspresso.taskdef.jsonnet" | grep -vE "^./template" \
+            | xargs -I{} -P10 bash -c \
+            '[ "$(ecspresso --config={} diff)" = "" ] || ecspresso --config={} register'
+      - name: ecschedule apply
+        working-directory: "ecspresso/reviewapps"
+        run: |
+          find . -name "ecschedule.jsonnet" | grep -vE "^./template" \
+            | xargs -I{} -P10 bash -c \
+            'ecschedule apply -conf {} -all'
+
+      #
+      # ecspresso
+      #
+      - name: run ecspresso
+        working-directory: "ecspresso/reviewapps"
+        run: |
+          # shellcheck disable=SC2016
+          find . -name "ecspresso.jsonnet" | grep -vE "^./template" \
+            | xargs -I{} -P10 bash -c \
+            '[ "$(ecspresso --config={} diff)" = "" ] || ecspresso --config={} deploy'

--- a/.github/workflows/ecspresso-stg.yml
+++ b/.github/workflows/ecspresso-stg.yml
@@ -1,0 +1,68 @@
+name: ecspresso deploy (stg)
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - 'ecspresso/stg/**'
+      - 'ecspresso/base/**'
+      - '.github/workflows/ecspresso-stg.yml'
+  repository_dispatch:
+    types: [trigger-ecspresso]
+
+concurrency: ecspresso-stg
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  ecspresso:
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+      id-token: write
+    timeout-minutes: 30
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
+        with:
+          aws-region: ap-northeast-1
+          role-to-assume: "arn:aws:iam::607167088920:role/github-actions-dreamkast"
+
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Install ecspresso
+        uses: kayac/ecspresso@e048f284f6b81b4f99085a963838c762be99361c # v2
+      - name: Install ecschedule
+        uses: Songmu/ecschedule@5fcc5e5b08af78d797c2b9e94b6f9a8ff9f7b626 # v0.15.3
+
+      #
+      # ecschedule
+      #
+      - name: register taskdef for ecschedule
+        working-directory: "ecspresso/stg"
+        run: |
+          # shellcheck disable=SC2016
+          find . -name "ecspresso.taskdef.jsonnet" | grep -vE "^./template" \
+            | xargs -I{} -P10 bash -c \
+            '[ "$(ecspresso --config={} diff)" = "" ] || ecspresso --config={} register'
+      - name: ecschedule apply
+        working-directory: "ecspresso/stg"
+        run: |
+          find . -name "ecschedule.jsonnet" | grep -vE "^./template" \
+            | xargs -I{} -P10 bash -c \
+            'ecschedule apply -conf {} -all'
+
+      #
+      # ecspresso
+      #
+      - name: run ecspresso
+        working-directory: "ecspresso/stg"
+        run: |
+          # shellcheck disable=SC2016
+          find . -name "ecspresso.jsonnet" | grep -vE "^./template" \
+            | xargs -I{} -P10 bash -c \
+            '[ "$(ecspresso --config={} diff)" = "" ] || ecspresso --config={} deploy'


### PR DESCRIPTION
## Summary
- 単一の matrix ベースの `ecspresso.yml` を `ecspresso-prod.yml` / `ecspresso-stg.yml` / `ecspresso-reviewapps.yml` に分割
- 環境ごとに独立した concurrency group (`ecspresso-prod` / `ecspresso-stg` / `ecspresso-reviewapps`) を持たせ、ある環境の deploy 詰まりが他環境をブロックしないように
- `paths` フィルタで `ecspresso/<env>/**` + `ecspresso/base/**` + 自身の workflow のみで起動するように
- preview の concurrency group も `ecspresso-preview` に分離（deploy と直列化されていた挙動を独立化）

## Background
stg の bump で ECR に存在しない image tag を deploy しようとして 15 分 timeout、その間 `concurrency: ecspresso` 共有のため prod や reviewapps の deploy も詰まる状況が発生していた。今回の分割により、この種のブロックは無くなる。
（image 不在自体への対処は別途、ECR pre-flight check や ecspresso `--timeout` 短縮で別 PR 検討予定）

## Test plan
- [ ] PR 作成後、`ecspresso preview` が動くこと
- [ ] マージ後、`ecspresso/<env>/` に変更を含む bump で対応する 1 環境のみ deploy が起動すること
- [ ] `ecspresso/base/**` 変更で 3 環境すべて起動すること
- [ ] `repository_dispatch (trigger-ecspresso)` で 3 環境すべて起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)