### PR TITLE
Switch ECS to ARM64 (stg and reviewapps)

### DIFF
--- a/ecspresso/base/dreamkast-fifo-worker.libsonnet
+++ b/ecspresso/base/dreamkast-fifo-worker.libsonnet
@@ -27,6 +27,7 @@ local util = import './util.libsonnet';
     executionRoleName,
     imageTag,
     region,
+    cpuArchitecture='X86_64',
     rdbInternalEndpoint,
     redisInternalEndpoint,
     s3BucketName,
@@ -54,6 +55,10 @@ local util = import './util.libsonnet';
     memory: '%s' % [memory],
     networkMode: 'awsvpc',
     requiresCompatibilities: ['FARGATE'],
+    runtimePlatform: {
+      cpuArchitecture: cpuArchitecture,
+      operatingSystemFamily: 'LINUX',
+    },
     volumes: [],
     containerDefinitions: [
       {

--- a/ecspresso/base/dreamkast-ui.libsonnet
+++ b/ecspresso/base/dreamkast-ui.libsonnet
@@ -35,6 +35,7 @@ local util = import './util.libsonnet';
     executionRoleName,
     imageTag,
     region,
+    cpuArchitecture='X86_64',
     dkEndpoint,
     dkWeaverEndpoint,
     dkUiSecretManagerName,
@@ -56,6 +57,10 @@ local util = import './util.libsonnet';
     memory: '%s' % [memory],
     networkMode: 'awsvpc',
     requiresCompatibilities: ['FARGATE'],
+    runtimePlatform: {
+      cpuArchitecture: cpuArchitecture,
+      operatingSystemFamily: 'LINUX',
+    },
     volumes: [],
     containerDefinitions: [
       {

--- a/ecspresso/base/dreamkast-weaver.libsonnet
+++ b/ecspresso/base/dreamkast-weaver.libsonnet
@@ -35,6 +35,7 @@ local util = import './util.libsonnet';
     executionRoleName,
     imageTag,
     region,
+    cpuArchitecture='X86_64',
     dkInternalEndpoint,
     rdbInternalEndpoint,
     rdsSecretManagerName,
@@ -118,6 +119,10 @@ local util = import './util.libsonnet';
     memory: '%s' % [memory],
     networkMode: 'awsvpc',
     requiresCompatibilities: ['FARGATE'],
+    runtimePlatform: {
+      cpuArchitecture: cpuArchitecture,
+      operatingSystemFamily: 'LINUX',
+    },
     volumes: [],
     containerDefinitions: [
       root.containerDefinitionCommon {

--- a/ecspresso/base/dreamkast.libsonnet
+++ b/ecspresso/base/dreamkast.libsonnet
@@ -37,6 +37,7 @@ local util = import './util.libsonnet';
     executionRoleName,
     imageTag,
     region,
+    cpuArchitecture='X86_64',
     dkApiEndpoint,
     dkWeaverEndpoint,
     rdbInternalEndpoint,
@@ -168,6 +169,10 @@ local util = import './util.libsonnet';
     memory: '%s' % [memory],
     networkMode: 'awsvpc',
     requiresCompatibilities: ['FARGATE'],
+    runtimePlatform: {
+      cpuArchitecture: cpuArchitecture,
+      operatingSystemFamily: 'LINUX',
+    },
     volumes: [],
     containerDefinitions: [
       //

--- a/ecspresso/base/mysql.libsonnet
+++ b/ecspresso/base/mysql.libsonnet
@@ -28,6 +28,7 @@ local const = import './const.libsonnet';
     executionRoleName,
     imageTag,
     region,
+    cpuArchitecture='X86_64',
     enableLogging=false,
   ):: {
     executionRoleArn: 'arn:aws:iam::%s:role/%s' % [const.accountID, executionRoleName],
@@ -37,6 +38,10 @@ local const = import './const.libsonnet';
     memory: '%s' % [memory],
     networkMode: 'awsvpc',
     requiresCompatibilities: ['FARGATE'],
+    runtimePlatform: {
+      cpuArchitecture: cpuArchitecture,
+      operatingSystemFamily: 'LINUX',
+    },
     volumes: [],
     containerDefinitions: [
       {

--- a/ecspresso/base/redis.libsonnet
+++ b/ecspresso/base/redis.libsonnet
@@ -28,6 +28,7 @@ local const = import './const.libsonnet';
     executionRoleName,
     imageTag,
     region,
+    cpuArchitecture='X86_64',
     enableLogging=false,
   ):: {
     executionRoleArn: 'arn:aws:iam::%s:role/%s' % [const.accountID, executionRoleName],
@@ -37,6 +38,10 @@ local const = import './const.libsonnet';
     memory: '%s' % [memory],
     networkMode: 'awsvpc',
     requiresCompatibilities: ['FARGATE'],
+    runtimePlatform: {
+      cpuArchitecture: cpuArchitecture,
+      operatingSystemFamily: 'LINUX',
+    },
     volumes: [],
     containerDefinitions: [
       {

--- a/ecspresso/reviewapps/template-dk/dreamkast-fifo-worker/task-def.jsonnet
+++ b/ecspresso/reviewapps/template-dk/dreamkast-fifo-worker/task-def.jsonnet
@@ -8,6 +8,7 @@ dreamkast_fifo_worker.taskDef(
   imageTag=const.imageTags.dreamkast_ecs,
 
   region=const.region,
+  cpuArchitecture='ARM64',
   rdbInternalEndpoint=const.internalEndpoints.rdb,
   redisInternalEndpoint=const.internalEndpoints.redis,
 

--- a/ecspresso/reviewapps/template-dk/dreamkast/task-def.jsonnet
+++ b/ecspresso/reviewapps/template-dk/dreamkast/task-def.jsonnet
@@ -8,6 +8,7 @@ dreamkast.taskDef(
   imageTag=const.imageTags.dreamkast_ecs,
 
   region=const.region,
+  cpuArchitecture='ARM64',
   dkApiEndpoint=const.externalEndpoints.dkApi,
   dkWeaverEndpoint=const.externalEndpoints.dkWeaver,
   rdbInternalEndpoint=const.internalEndpoints.rdb,

--- a/ecspresso/reviewapps/template-dk/harvestjob/task-def.jsonnet
+++ b/ecspresso/reviewapps/template-dk/harvestjob/task-def.jsonnet
@@ -110,5 +110,9 @@ local roleName = 'dreamkast-dev-ecs-harvestjob';
   requiresCompatibilities: [
     'FARGATE',
   ],
+  runtimePlatform: {
+    cpuArchitecture: 'ARM64',
+    operatingSystemFamily: 'LINUX',
+  },
   volumes: [],
 }

--- a/ecspresso/reviewapps/template-dk/mysql/task-def.jsonnet
+++ b/ecspresso/reviewapps/template-dk/mysql/task-def.jsonnet
@@ -8,6 +8,7 @@ mysql.taskDef(
   imageTag=const.imageTags.mysql,
 
   region=const.region,
+  cpuArchitecture='ARM64',
 
   enableLogging=false,
 )

--- a/ecspresso/reviewapps/template-dk/redis/task-def.jsonnet
+++ b/ecspresso/reviewapps/template-dk/redis/task-def.jsonnet
@@ -8,6 +8,7 @@ redis.taskDef(
   imageTag=const.imageTags.redis,
 
   region=const.region,
+  cpuArchitecture='ARM64',
 
   enableLogging=false,
 )

--- a/ecspresso/reviewapps/template-ui/dreamkast-ui/task-def.jsonnet
+++ b/ecspresso/reviewapps/template-ui/dreamkast-ui/task-def.jsonnet
@@ -8,6 +8,7 @@ dreamkast_ui.taskDef(
   imageTag=const.imageTags.dreamkast_ui,
 
   region=const.region,
+  cpuArchitecture='ARM64',
   dkEndpoint=const.externalEndpoints.dk,
   dkWeaverEndpoint=const.externalEndpoints.dkWeaver,
 

--- a/ecspresso/reviewapps/template-weaver/dreamkast-weaver/task-def.jsonnet
+++ b/ecspresso/reviewapps/template-weaver/dreamkast-weaver/task-def.jsonnet
@@ -8,6 +8,7 @@ dreamkast_weaver.taskDef(
   imageTag=const.imageTags.dreamkast_weaver,
 
   region=const.region,
+  cpuArchitecture='ARM64',
   dkInternalEndpoint=const.internalEndpoints.dk,
   rdbInternalEndpoint=const.internalEndpoints.rdb,
 

--- a/ecspresso/reviewapps/template-weaver/mysql/task-def.jsonnet
+++ b/ecspresso/reviewapps/template-weaver/mysql/task-def.jsonnet
@@ -8,6 +8,7 @@ mysql.taskDef(
   imageTag=const.imageTags.mysql,
 
   region=const.region,
+  cpuArchitecture='ARM64',
 
   enableLogging=false,
 )

--- a/ecspresso/stg/dreamkast-fifo-worker/task-def.jsonnet
+++ b/ecspresso/stg/dreamkast-fifo-worker/task-def.jsonnet
@@ -9,6 +9,7 @@ dreamkast_fifo_worker.taskDef(
   imageTag=const.imageTags.dreamkast_ecs,
 
   region=const.region,
+  cpuArchitecture='ARM64',
   rdbInternalEndpoint=const.internalEndpoints.rdb,
   redisInternalEndpoint=const.internalEndpoints.redis,
 

--- a/ecspresso/stg/dreamkast-ui/task-def.jsonnet
+++ b/ecspresso/stg/dreamkast-ui/task-def.jsonnet
@@ -9,6 +9,7 @@ dreamkast_ui.taskDef(
   imageTag=const.imageTags.dreamkast_ui,
 
   region=const.region,
+  cpuArchitecture='ARM64',
   dkEndpoint=const.externalEndpoints.dk,
   dkWeaverEndpoint=const.externalEndpoints.dkWeaver,
 

--- a/ecspresso/stg/dreamkast-weaver/task-def.jsonnet
+++ b/ecspresso/stg/dreamkast-weaver/task-def.jsonnet
@@ -9,6 +9,7 @@ dreamkast_weaver.taskDef(
   imageTag=const.imageTags.dreamkast_weaver,
 
   region=const.region,
+  cpuArchitecture='ARM64',
   dkInternalEndpoint=const.internalEndpoints.dk,
   rdbInternalEndpoint=const.internalEndpoints.rdb,
 

--- a/ecspresso/stg/dreamkast/task-def.jsonnet
+++ b/ecspresso/stg/dreamkast/task-def.jsonnet
@@ -9,6 +9,7 @@ dreamkast.taskDef(
   imageTag=const.imageTags.dreamkast_ecs,
 
   region=const.region,
+  cpuArchitecture='ARM64',
   dkApiEndpoint=const.externalEndpoints.dkApi,
   dkWeaverEndpoint=const.externalEndpoints.dkWeaver,
   rdbInternalEndpoint=const.internalEndpoints.rdb,

--- a/ecspresso/stg/harvestjob/task-def.jsonnet
+++ b/ecspresso/stg/harvestjob/task-def.jsonnet
@@ -118,5 +118,9 @@ local roleName = 'dreamkast-dev-ecs-harvestjob';
   requiresCompatibilities: [
     'FARGATE',
   ],
+  runtimePlatform: {
+    cpuArchitecture: 'ARM64',
+    operatingSystemFamily: 'LINUX',
+  },
   volumes: [],
 }

--- a/ecspresso/stg/redis/task-def.jsonnet
+++ b/ecspresso/stg/redis/task-def.jsonnet
@@ -8,6 +8,7 @@ redis.taskDef(
   imageTag=const.imageTags.redis,
 
   region=const.region,
+  cpuArchitecture='ARM64',
 
   enableLogging=false,
 )


### PR DESCRIPTION
## 概要

ECS Fargate のタスクを **ARM64 (Graviton)** に切り替えます。まず **stg と reviewapps を先行**で切り替え、prod は別 PR でフォローアップします。

## 背景・前提

全アプリイメージ（`dreamkast-ecs` / `dreamkast-ui` / `dreamkast-weaver` / `dreamkast-otelcol`）は共通の reusable workflow で **amd64+arm64 のマルチアーチ manifest** をすでにビルド済みです。サイドカー / DB 用の `grafana/fluent-bit-plugin-loki` `mysql` `redis` `debian` も公式マルチアーチのため、タスクをそのまま ARM64 で動かせます。

これまで `runtimePlatform` はどこにも設定されておらず、全タスクが X86_64 デフォルトでした。

| Image | ARM64 |
|---|---|
| `dreamkast-ecs` / `dreamkast-ui` / `dreamkast-weaver` / `dreamkast-otelcol` | ✅ multi-arch |
| `fluent-bit-plugin-loki` / `mysql` / `redis` / `debian` | ✅ official multi-arch |
| `seaman` | ❌ amd64-only → X86_64 のまま据え置き |

## 変更内容

- 共通 base の `taskDef` に `cpuArchitecture`（デフォルト `X86_64`）パラメータを追加し `runtimePlatform` を出力（デフォルトは現状維持）。
- **stg + reviewapps** の呼び出し側で `cpuArchitecture='ARM64'` を指定。base を使わない単独 task-def（`stg/harvestjob`, `reviewapps/.../harvestjob`）には `ARM64` を直接記述。
- **prod は全サービス X86_64 のまま**（フォローアップで base 呼び出しに `cpuArchitecture='ARM64'` を足すだけ）。`seaman` も据え置き。

## デプロイ時の注意

- stg は `ecspresso/base/**` 変更で stg ワークフローが発火し ARM へローリング更新されます。**deployment circuit breaker が無効**設定のため、ARM タスクが起動失敗しても自動ロールバックしません。最初のデプロイは `ecspresso diff` / 起動ログを見ながら進めてください。
- prod では base に `runtimePlatform: X86_64` が明示出力されますが、Fargate は AWS 側が同値を自動補完するため `ecspresso diff` は差分なしの想定です。prod へ何かデプロイする前に no-op を確認してください。

## 検証

- `jsonnet` で全 task-def をレンダリングし、stg=ARM64 / prod=X86_64 を確認。
- `jsonnetfmt` 適用済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)