### PR TITLE
ReviewApp の MySQL TLS エラーを修正し MySQL を 8.4.9 にアップグレード

### DIFF
--- a/ecspresso/base/dreamkast.libsonnet
+++ b/ecspresso/base/dreamkast.libsonnet
@@ -115,6 +115,10 @@ local util = import './util.libsonnet';
           name: 'REVIEW_APP',
           value: 'true',
         },
+        {
+          name: 'MYSQL_SSL_MODE',
+          value: 'disabled',
+        },
       ] else [],
       secrets: [
         // from rails-app-secret Secret

--- a/ecspresso/reviewapps/template-dk/const.libsonnet
+++ b/ecspresso/reviewapps/template-dk/const.libsonnet
@@ -55,6 +55,6 @@
   imageTags: {
     dreamkast_ecs: error 'you must replace this value',
     redis: '6.0',
-    mysql: '8.0.33',
+    mysql: '8.4.9',
   },
 }


### PR DESCRIPTION
## 概要

dreamkast #2843 (MySQL 8.4.9 アップグレード) の ReviewApp 起動エラーを修正します。

## 問題

ReviewApp が以下のエラーで起動しない:
```
TLS/SSL error: self-signed certificate in certificate chain
```

`database.yml` の production 設定が `MYSQL_SSL_MODE` 未設定時に `verify_identity`（CA 検証あり）をデフォルト使用するが、ReviewApp の MySQL コンテナは自己署名証明書を使用するため CA 検証が失敗していた。

## 修正内容

- `ecspresso/base/dreamkast.libsonnet`: ReviewApp 用環境変数に `MYSQL_SSL_MODE=disabled` を追加
- `ecspresso/reviewapps/template-dk/const.libsonnet`: MySQL イメージを `8.0.33` → `8.4.9` に更新

## 関連 PR

- cloudnativedaysjp/dreamkast#2843

🤖 Generated with [Claude Code](https://claude.com/claude-code)