### PR TITLE
Switch ECS to ARM64 (prod)

### DIFF
--- a/ecspresso/prod/dreamkast-fifo-worker/task-def.jsonnet
+++ b/ecspresso/prod/dreamkast-fifo-worker/task-def.jsonnet
@@ -9,6 +9,7 @@ dreamkast_fifo_worker.taskDef(
   imageTag=const.imageTags.dreamkast_ecs,
 
   region=const.region,
+  cpuArchitecture='ARM64',
   rdbInternalEndpoint=const.internalEndpoints.rdb,
   redisInternalEndpoint=const.internalEndpoints.redis,
 

--- a/ecspresso/prod/dreamkast-ui/task-def.jsonnet
+++ b/ecspresso/prod/dreamkast-ui/task-def.jsonnet
@@ -9,6 +9,7 @@ dreamkast_ui.taskDef(
   imageTag=const.imageTags.dreamkast_ui,
 
   region=const.region,
+  cpuArchitecture='ARM64',
   dkEndpoint=const.externalEndpoints.dk,
   dkWeaverEndpoint=const.externalEndpoints.dkWeaver,
 

--- a/ecspresso/prod/dreamkast-weaver/task-def.jsonnet
+++ b/ecspresso/prod/dreamkast-weaver/task-def.jsonnet
@@ -9,6 +9,7 @@ dreamkast_weaver.taskDef(
   imageTag=const.imageTags.dreamkast_weaver,
 
   region=const.region,
+  cpuArchitecture='ARM64',
   dkInternalEndpoint=const.internalEndpoints.dk,
   rdbInternalEndpoint=const.internalEndpoints.rdb,
 

--- a/ecspresso/prod/dreamkast/task-def.jsonnet
+++ b/ecspresso/prod/dreamkast/task-def.jsonnet
@@ -11,6 +11,7 @@ dreamkast.taskDef(
   imageTag=const.imageTags.dreamkast_ecs,
 
   region=const.region,
+  cpuArchitecture='ARM64',
   dkApiEndpoint=const.externalEndpoints.dkApi,
   dkWeaverEndpoint=const.externalEndpoints.dkWeaver,
   rdbInternalEndpoint=const.internalEndpoints.rdb,

--- a/ecspresso/prod/harvestjob/task-def.jsonnet
+++ b/ecspresso/prod/harvestjob/task-def.jsonnet
@@ -118,5 +118,9 @@ local roleName = 'dreamkast-prod-ecs-harvestjob';
   requiresCompatibilities: [
     'FARGATE',
   ],
+  runtimePlatform: {
+    cpuArchitecture: 'ARM64',
+    operatingSystemFamily: 'LINUX',
+  },
   volumes: [],
 }

--- a/ecspresso/prod/medialive-alert/task-def.jsonnet
+++ b/ecspresso/prod/medialive-alert/task-def.jsonnet
@@ -106,5 +106,9 @@ local roleName = 'dreamkast-prod-ecs-medialive-alert';
   requiresCompatibilities: [
     'FARGATE',
   ],
+  runtimePlatform: {
+    cpuArchitecture: 'ARM64',
+    operatingSystemFamily: 'LINUX',
+  },
   volumes: [],
 }

--- a/ecspresso/prod/post-registration/task-def.jsonnet
+++ b/ecspresso/prod/post-registration/task-def.jsonnet
@@ -106,5 +106,9 @@ local roleName = 'dreamkast-prod-ecs-post-registration';
   requiresCompatibilities: [
     'FARGATE',
   ],
+  runtimePlatform: {
+    cpuArchitecture: 'ARM64',
+    operatingSystemFamily: 'LINUX',
+  },
   volumes: [],
 }


### PR DESCRIPTION
## Summary

#5631 のフォローアップです。stg + reviewapps で安定稼働を確認した ARM64 (Graviton) 移行を **prod** に反映します。

multi-arch イメージ（`dreamkast-ecs` / `dreamkast-weaver` / `dreamkast-ui`）を使う prod の全 Fargate タスクを ARM64 化します。

## 変更内容

| サービス | 対応 | アーキ |
|---|---|---|
| dreamkast | base taskDef の `cpuArchitecture` パラメータ | ARM64 |
| dreamkast-weaver | 同上 | ARM64 |
| dreamkast-ui | 同上 | ARM64 |
| dreamkast-fifo-worker | 同上 | ARM64 |
| harvestjob | `runtimePlatform` ブロック追加 | ARM64 |
| post-registration | `runtimePlatform` ブロック追加 | ARM64 |
| medialive-alert | `runtimePlatform` ブロック追加 | ARM64 |
| **seaman** | 変更なし | **X86_64**（イメージが amd64-only のため据え置き）|

## 補足

- weaver は Dockerfile の cross-compile 問題（`exec format error`）が weaver #135/#136 で解決済み、stg で arm64 動作確認済み。
- harvestjob / post-registration / medialive-alert はいずれも stg でも稼働している multi-arch な `dreamkast-ecs` イメージを使用。
- `jsonnet` でレンダリングし、対象7ファイルすべてで `cpuArchitecture: ARM64` を、seaman が X86_64 のままであることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)