### PR TITLE
review app の MySQL に solid_cable 用DB(dreamkast_cable)を作成

### DIFF
--- a/ecspresso/base/mysql.libsonnet
+++ b/ecspresso/base/mysql.libsonnet
@@ -47,8 +47,13 @@ local const = import './const.libsonnet';
       {
         name: 'mysql',
         image: '%s.dkr.ecr.%s.amazonaws.com/ecr-public/docker/library/mysql:%s' % [const.accountID, region, imageTag],
-        command: [],
-        entryPoint: [],
+        // solid_cable 用の専用データベース(dreamkast_cable)を review app 用 MySQL にも作成する。
+        // 公式 MySQL イメージは MYSQL_DATABASE を1つしか作らないため、
+        // 初期化スクリプト(/docker-entrypoint-initdb.d)を注入してから mysqld を起動する。
+        entryPoint: ['bash', '-c'],
+        command: [
+          "echo \"CREATE DATABASE IF NOT EXISTS dreamkast_cable CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci; GRANT ALL PRIVILEGES ON dreamkast_cable.* TO 'user'@'%';\" > /docker-entrypoint-initdb.d/10-create-cable-db.sql && exec docker-entrypoint.sh mysqld",
+        ],
         essential: true,
         restartPolicy: { enabled: true },
         cpu: cpu,


### PR DESCRIPTION
## 概要

脱Redis 対応（[dreamkast#2844](https://github.com/cloudnativedaysjp/dreamkast/pull/2844)）で Action Cable を **solid_cable の専用DB構成**（`dreamkast_cable`）へ移行しました。これに伴い、review app 用の MySQL コンテナに `dreamkast_cable` スキーマを作成する必要があります。

## 背景（デプロイが失敗していた原因）

dk-2844 の review app デプロイで、`dk-2844-dreamkast`（アプリ本体）のタスクが起動直後に落ち続け、`exceeded max wait time for ServicesStable` で失敗していました。

- 公式 MySQL イメージは `MYSQL_DATABASE` を1つ（`dreamkast`）しか作らない。
- アプリの `initdb` コンテナが実行する `bundle exec rails db:migrate` は、マルチDB構成のため `dreamkast_cable` にも接続してマイグレーションしようとする。
- `dreamkast_cable` が存在せず接続に失敗 → コンテナ即死 → タスクが steady state に到達できない。

## 変更内容

`ecspresso/base/mysql.libsonnet`（review app 専用の MySQL 定義。全 review app が import）で、コンテナ起動時に初期化スクリプトを注入して `dreamkast_cable` を作成し、`user` に権限付与してから `mysqld` を起動するようにしました。

```
entryPoint: ['bash', '-c'],
command: [
  "echo \"CREATE DATABASE IF NOT EXISTS dreamkast_cable ...; GRANT ALL PRIVILEGES ON dreamkast_cable.* TO 'user'@'%';\" > /docker-entrypoint-initdb.d/10-create-cable-db.sql && exec docker-entrypoint.sh mysqld",
],
```

- review app の MySQL はボリューム無しの使い捨てコンテナなので、毎起動が初回初期化となり `/docker-entrypoint-initdb.d` が確実に実行されます。
- `user`@`%` は MySQL エントリポイントが initdb スクリプト実行前に作成するため、GRANT 対象が存在します。

## 影響範囲・注意

- **prod / stg は対象外**（RDS 利用のため `mysql.libsonnet` は使われない）。prod / stg では **RDS 側に `<db>_cable` スキーマを作成し、アプリユーザーへ権限付与する運用対応が別途必要**です（dreamkast#2844 マージ前に実施しないと本番デプロイの `db:migrate` が失敗します）。
- review app にはまだ `redis` サービスが残っていますが、アプリからは未使用です（本PRのスコープ外。別途撤去可）。

## 動作確認

- `jsonnet ecspresso/reviewapps/dk-2844/mysql/task-def.jsonnet` でレンダリングし、`entryPoint`/`command` が意図通り出力されることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
