### PR TITLE
sessions テーブルを日次で trim する ECS スケジュールタスクを追加

### DIFF
--- a/ecspresso/prod/sessions-trim/ecschedule.jsonnet
+++ b/ecspresso/prod/sessions-trim/ecschedule.jsonnet
@@ -1,0 +1,25 @@
+local const = import '../const.libsonnet';
+{
+  region: const.region,
+  cluster: const.cluster,
+  role: const.taskTargetRoleName,
+  rules: [
+    {
+      name: 'sessions-trim',
+      // 03:00 JST (18:00 UTC) の低トラフィック帯に実行する。
+      scheduleExpression: 'cron(0 18 * * ? *)',
+      taskDefinition: 'dreamkast-prod-sessions-trim',
+      launch_type: 'FARGATE',
+      platform_version: 'LATEST',
+      network_configuration: {
+        aws_vpc_configuration: {
+          subnets: const.publicSubnetIDs,
+          security_groups: [
+            'sg-005b97d49a4b8431e',  // dreamkast-prod-ecs-task-registration
+          ],
+          assign_public_ip: 'ENABLED',
+        },
+      },
+    },
+  ],
+}

--- a/ecspresso/prod/sessions-trim/ecspresso.taskdef.jsonnet
+++ b/ecspresso/prod/sessions-trim/ecspresso.taskdef.jsonnet
@@ -1,0 +1,6 @@
+{
+  region: 'ap-northeast-1',
+  cluster: 'dreamkast-prod',
+  task_definition: 'task-def.jsonnet',
+  timeout: '5m',
+}

--- a/ecspresso/prod/sessions-trim/task-def.jsonnet
+++ b/ecspresso/prod/sessions-trim/task-def.jsonnet
@@ -1,0 +1,115 @@
+local const = import '../const.libsonnet';
+local family = 'dreamkast-prod-sessions-trim';
+// この rake task は AWS API を呼ばないため、専用ロールは作らず
+// post-registration のロール/SGを流用する(いずれも SSM 用の権限と全許可 egress のみ)。
+local roleName = 'dreamkast-prod-ecs-post-registration';
+
+{
+  containerDefinitions: [
+    {
+      local container = self,
+
+      name: 'dreamkast',
+      image: '607167088920.dkr.ecr.%s.amazonaws.com/dreamkast-ecs:%s' % [const.region, const.imageTags.dreamkast_ecs],
+      essential: true,
+      entryPoint: [
+        '/bin/bash',
+        '-c',
+      ],
+      // activerecord-session_store は期限切れセッションを自動削除しないため、
+      // gem が提供する db:sessions:trim を日次で実行して sessions テーブルの肥大化を防ぐ。
+      command: [
+        'bundle exec rake db:sessions:trim',
+      ],
+      environment: [
+        {
+          name: 'RAILS_ENV',
+          value: 'production',
+        },
+        {
+          name: 'MYSQL_HOST',
+          value: const.internalEndpoints.rdb,
+        },
+        {
+          name: 'MYSQL_DATABASE',
+          value: 'dreamkast',
+        },
+        {
+          // session_store の expire_after は 1 週間。余裕を見て 14 日より古い行を削除する。
+          name: 'SESSION_DAYS_TRIM_THRESHOLD',
+          value: '14',
+        },
+        {
+          name: 'SENTRY_DSN',
+          value: const.sentry.dsn,
+        },
+        {
+          name: 'S3_BUCKET',
+          value: 'dreamkast-prod-bucket',
+        },
+        {
+          name: 'S3_REGION',
+          value: const.region,
+        },
+        {
+          name: 'DREAMKAST_NAMESPACE',
+          value: 'dreamkast',
+        },
+      ],
+      secrets: [
+        {
+          name: 'RAILS_MASTER_KEY',
+          valueFrom: 'arn:aws:secretsmanager:%s:607167088920:secret:%s' % [const.region, const.secretManager.railsApp],
+        },
+        {
+          name: 'AUTH0_CLIENT_ID',
+          valueFrom: 'arn:aws:secretsmanager:%s:607167088920:secret:%s:AUTH0_CLIENT_ID::' % [const.region, const.secretManager.dk],
+        },
+        {
+          name: 'AUTH0_CLIENT_SECRET',
+          valueFrom: 'arn:aws:secretsmanager:%s:607167088920:secret:%s:AUTH0_CLIENT_SECRET::' % [const.region, const.secretManager.dk],
+        },
+        {
+          name: 'AUTH0_DOMAIN',
+          valueFrom: 'arn:aws:secretsmanager:%s:607167088920:secret:%s:AUTH0_DOMAIN::' % [const.region, const.secretManager.dk],
+        },
+        {
+          name: 'MYSQL_USER',
+          valueFrom: 'arn:aws:secretsmanager:%s:607167088920:secret:%s:username::' % [const.region, const.secretManager.rds],
+        },
+        {
+          name: 'MYSQL_PASSWORD',
+          valueFrom: 'arn:aws:secretsmanager:%s:607167088920:secret:%s:password::' % [const.region, const.secretManager.rds],
+        },
+      ],
+
+      logConfiguration: {
+        logDriver: 'awslogs',
+        options: {
+          'awslogs-create-group': 'true',
+          'awslogs-group': family,
+          'awslogs-region': const.region,
+          'awslogs-stream-prefix': container.name,
+        },
+      },
+
+      cpu: 256,
+      memory: 512,
+      memoryReservation: 512,
+    },
+  ],
+  family: family,
+  cpu: '256',
+  memory: '512',
+  executionRoleArn: 'arn:aws:iam::607167088920:role/%s' % [const.executionRoleName],
+  taskRoleArn: 'arn:aws:iam::607167088920:role/%s' % [roleName],
+  networkMode: 'awsvpc',
+  requiresCompatibilities: [
+    'FARGATE',
+  ],
+  runtimePlatform: {
+    cpuArchitecture: 'ARM64',
+    operatingSystemFamily: 'LINUX',
+  },
+  volumes: [],
+}

--- a/ecspresso/stg/sessions-trim/ecschedule.jsonnet
+++ b/ecspresso/stg/sessions-trim/ecschedule.jsonnet
@@ -1,0 +1,25 @@
+local const = import '../const.libsonnet';
+{
+  region: const.region,
+  cluster: const.cluster,
+  role: const.taskTargetRoleName,
+  rules: [
+    {
+      name: 'sessions-trim',
+      // 03:00 JST (18:00 UTC) の低トラフィック帯に実行する。
+      scheduleExpression: 'cron(0 18 * * ? *)',
+      taskDefinition: 'dreamkast-stg-sessions-trim',
+      launch_type: 'FARGATE',
+      platform_version: 'LATEST',
+      network_configuration: {
+        aws_vpc_configuration: {
+          subnets: const.publicSubnetIDs,
+          security_groups: [
+            'sg-05592a72e569c245b',  // dreamkast-dev-ecs-harvestjob
+          ],
+          assign_public_ip: 'ENABLED',
+        },
+      },
+    },
+  ],
+}

--- a/ecspresso/stg/sessions-trim/ecspresso.taskdef.jsonnet
+++ b/ecspresso/stg/sessions-trim/ecspresso.taskdef.jsonnet
@@ -1,0 +1,6 @@
+{
+  region: 'us-west-2',
+  cluster: 'dreamkast-stg',
+  task_definition: 'task-def.jsonnet',
+  timeout: '5m',
+}

--- a/ecspresso/stg/sessions-trim/task-def.jsonnet
+++ b/ecspresso/stg/sessions-trim/task-def.jsonnet
@@ -1,0 +1,115 @@
+local const = import '../const.libsonnet';
+local family = 'dreamkast-stg-sessions-trim';
+// この rake task は AWS API を呼ばないため、専用ロールは作らず
+// harvestjob のロール/SGを流用する(いずれも SSM 用の権限と全許可 egress のみ)。
+local roleName = 'dreamkast-dev-ecs-harvestjob';
+
+{
+  containerDefinitions: [
+    {
+      local container = self,
+
+      name: 'dreamkast',
+      image: '607167088920.dkr.ecr.%s.amazonaws.com/dreamkast-ecs:%s' % [const.region, const.imageTags.dreamkast_ecs],
+      essential: true,
+      entryPoint: [
+        '/bin/bash',
+        '-c',
+      ],
+      // activerecord-session_store は期限切れセッションを自動削除しないため、
+      // gem が提供する db:sessions:trim を日次で実行して sessions テーブルの肥大化を防ぐ。
+      command: [
+        'bundle exec rake db:sessions:trim',
+      ],
+      environment: [
+        {
+          name: 'RAILS_ENV',
+          value: 'production',
+        },
+        {
+          name: 'MYSQL_HOST',
+          value: const.internalEndpoints.rdb,
+        },
+        {
+          name: 'MYSQL_DATABASE',
+          value: 'dreamkast',
+        },
+        {
+          // session_store の expire_after は 1 週間。余裕を見て 14 日より古い行を削除する。
+          name: 'SESSION_DAYS_TRIM_THRESHOLD',
+          value: '14',
+        },
+        {
+          name: 'SENTRY_DSN',
+          value: 'https://a1c3137217d913ed746bfda3ef9c63ac@o414348.ingest.us.sentry.io/4509089544929280',
+        },
+        {
+          name: 'S3_BUCKET',
+          value: 'dreamkast-stg-bucket',
+        },
+        {
+          name: 'S3_REGION',
+          value: const.region,
+        },
+        {
+          name: 'DREAMKAST_NAMESPACE',
+          value: 'dreamkast-staging',
+        },
+      ],
+      secrets: [
+        {
+          name: 'RAILS_MASTER_KEY',
+          valueFrom: 'arn:aws:secretsmanager:%s:607167088920:secret:%s' % [const.region, const.secretManager.railsApp],
+        },
+        {
+          name: 'AUTH0_CLIENT_ID',
+          valueFrom: 'arn:aws:secretsmanager:%s:607167088920:secret:%s:AUTH0_CLIENT_ID::' % [const.region, const.secretManager.dk],
+        },
+        {
+          name: 'AUTH0_CLIENT_SECRET',
+          valueFrom: 'arn:aws:secretsmanager:%s:607167088920:secret:%s:AUTH0_CLIENT_SECRET::' % [const.region, const.secretManager.dk],
+        },
+        {
+          name: 'AUTH0_DOMAIN',
+          valueFrom: 'arn:aws:secretsmanager:%s:607167088920:secret:%s:AUTH0_DOMAIN::' % [const.region, const.secretManager.dk],
+        },
+        {
+          name: 'MYSQL_USER',
+          valueFrom: 'arn:aws:secretsmanager:%s:607167088920:secret:%s:username::' % [const.region, const.secretManager.rds],
+        },
+        {
+          name: 'MYSQL_PASSWORD',
+          valueFrom: 'arn:aws:secretsmanager:%s:607167088920:secret:%s:password::' % [const.region, const.secretManager.rds],
+        },
+      ],
+
+      logConfiguration: {
+        logDriver: 'awslogs',
+        options: {
+          'awslogs-create-group': 'true',
+          'awslogs-group': family,
+          'awslogs-region': const.region,
+          'awslogs-stream-prefix': container.name,
+        },
+      },
+
+      cpu: 256,
+      memory: 512,
+      memoryReservation: 512,
+    },
+  ],
+  family: family,
+  cpu: '256',
+  memory: '512',
+  executionRoleArn: 'arn:aws:iam::607167088920:role/%s' % [const.executionRoleName],
+  taskRoleArn: 'arn:aws:iam::607167088920:role/%s' % [roleName],
+  networkMode: 'awsvpc',
+  requiresCompatibilities: [
+    'FARGATE',
+  ],
+  runtimePlatform: {
+    cpuArchitecture: 'ARM64',
+    operatingSystemFamily: 'LINUX',
+  },
+  volumes: [],
+}


### PR DESCRIPTION
## 概要

脱Redis 対応 ([dreamkast#2844](https://github.com/cloudnativedaysjp/dreamkast/pull/2844)) でセッションストアを `redis-session-store` から `activerecord-session_store` へ移行するのに伴い、`sessions` テーブルを日次で掃除する ECS スケジュールタスクを prod / stg に追加します。

## なぜ必要か

`activerecord-session_store` は**期限切れセッションを自動削除しません**。`config/initializers/session_store.rb` の `expire_after: 1.week` はクッキー側の有効期限で、DB の行は残り続けます。gem の README も「maintenance をしないと sessions テーブルが無制限に肥大する」と明記し、`db:sessions:trim` の日次実行を推奨しています。

dreamkast のセッションには Auth0 の `userinfo`（メールアドレス等）が入るため、容量面だけでなくプライバシー面でも期限切れデータを残したくありません。

## 変更内容

| | prod | stg |
|---|---|---|
| ディレクトリ | `ecspresso/prod/sessions-trim/` | `ecspresso/stg/sessions-trim/` |
| task definition | `dreamkast-prod-sessions-trim` | `dreamkast-stg-sessions-trim` |
| スケジュール | `cron(0 18 * * ? *)` = 03:00 JST | 同左 |
| command | `bundle exec rake db:sessions:trim` | 同左 |
| cpu / memory | 256 / 512 | 同左 |

`db:sessions:trim` は gem が Railtie 経由で提供する rake task（`rake_tasks { load .../tasks/database.rake }`）なので、**dreamkast 側の実装追加は不要**です。

### 設計上の判断

- **削除閾値**: `SESSION_DAYS_TRIM_THRESHOLD=14`。`expire_after` が 1 週間なので、余裕を見て 2 週間より古い行を削除します（gem のデフォルトは 30 日）。
- **IAM ロール / SG の流用**: この rake task は AWS API を一切呼ばないため専用ロールは作らず、prod は `dreamkast-prod-ecs-post-registration`、stg は `dreamkast-dev-ecs-harvestjob` のロールと SG を流用しています。いずれも SSM 用の権限と全許可 egress のみで、RDS への到達性は既存タスクで実績があります。terraform 側の変更を不要にするためですが、分けたほうが良ければ対応します。
- **env / secrets**: prod は post-registration、stg は harvestjob の task-def を踏襲し、不要な `REDIS_URL` / `SLACK_*` / `SQS_*` を落としています。
- **workflow 変更なし**: `ecspresso-prod.yml` / `ecspresso-stg.yml` は `find . -name "ecschedule.jsonnet"` / `ecspresso.taskdef.jsonnet` で自動検出するため、ディレクトリを足すだけで CD に乗ります。

## ⚠️ マージ順序

**dreamkast#2844 がリリースされ、`const.libsonnet` の `imageTags.dreamkast_ecs` が更新されたあとにマージしてください。**

先にマージすると、`db:sessions:trim` を持たない（= `activerecord-session_store` が入っていない）イメージに対してスケジュールが動き、`Don't know how to build task` で日次失敗します。害はなくリリース後に自然に解消しますが、無駄なアラート/ログを避けるためです。

## 動作確認

- `jsonnetfmt -i`（CI の ecspresso format と同じ）適用済み
- `jsonnet` で prod / stg の 4 ファイルすべて評価が通ることを確認済み
- 実タスクの起動確認は stg のスケジュール初回実行で行う想定です

## 関連

- dreamkast#2844 脱Redis: redis を solid_cable / activerecord-session_store へ移行
- ブランチ `add-cable-db-for-reviewapp`（review app 用 cable DB 作成、PR 未作成）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiZdLcEGBjBSTkbhYPSW4N
