### PR TITLE
stg の redis サービスを 0 台にする

### DIFF
--- a/ecspresso/reviewapps/template-dk/redis/service-def.jsonnet
+++ b/ecspresso/reviewapps/template-dk/redis/service-def.jsonnet
@@ -1,8 +1,11 @@
 local redis = import '../../../base/redis.libsonnet';
 local const = import '../const.libsonnet';
 
+// 脱Redis (dreamkast#2844) により review app のアプリは Redis を参照しなくなったため 0 台にする。
+// 問題が無いことを確認できたら、このサービス定義と initialize.sh の redis 関連を削除する。
 redis.serviceDef(
   region=const.region,
+  replicas=0,
   subnetIDs=const.publicSubnetIDs,
   securityGroupID='sg-0ab649652e2dd6c9c',  // dreamkast-dev-ecs-redis
   serviceDiscoveryID=const.serviceDiscovery.redis,

--- a/ecspresso/stg/redis/service-def.jsonnet
+++ b/ecspresso/stg/redis/service-def.jsonnet
@@ -1,8 +1,11 @@
 local redis = import '../../base/redis.libsonnet';
 local const = import '../const.libsonnet';
 
+// 脱Redis (dreamkast#2844) により stg のアプリは Redis を参照しなくなったため 0 台にする。
+// 問題が無いことを確認できたら、このサービス定義と const.libsonnet の redis 関連を削除する。
 redis.serviceDef(
   region=const.region,
+  replicas=0,
   subnetIDs=const.publicSubnetIDs,
   securityGroupID='sg-0ab649652e2dd6c9c',  // dreamkast-dev-ecs-redis
   serviceDiscoveryID=const.serviceDiscovery.redis,


### PR DESCRIPTION
## 概要

脱Redis（[dreamkast#2844](https://github.com/cloudnativedaysjp/dreamkast/pull/2844)）が stg にデプロイ済みになったので、stg の `redis` サービスを **0 台**にします。

```diff
 redis.serviceDef(
   region=const.region,
+  replicas=0,
   subnetIDs=const.publicSubnetIDs,
```

## なぜ削除ではなく 0 台か

見落としがあった場合に `replicas` を戻すだけで復旧できるようにするためです。サービス定義・サービスディスカバリ（`redis.staging.local`）・SG はそのまま残るので、切り戻しは PR 1本で済みます。

問題が無いことを確認できたら、このサービス定義と `const.libsonnet` の redis 関連（`imageTags.redis` / `internalEndpoints.redis` / `serviceDiscovery.redis`）、各 task-def の `REDIS_URL` をまとめて削除します。

## 安全性の根拠

- dreamkast#2844 が main にマージされ、**stg へデプロイ完了済み**
  - taskDef `dreamkast-stg-dk:727`（= `main-200874c7`）、`rolloutState=COMPLETED`
  - `initdb` コンテナが `exitCode=0` で終了（cable DB を含む `db:migrate` が正常完了）
  - `https://staging.dev.cloudnativedays.jp/` が HTTP 200
- アプリから Redis 依存（`redis` / `redis-session-store` gem、`REDIS_URL` の参照）は撤去済み
- stg で redis を参照しているのは各 task-def の `REDIS_URL` 環境変数のみで、アプリからは未使用

## 確認方法

マージ後、stg が引き続き正常であることに加えて、Action Cable が solid_cable 経由で動いていることを ECS Exec で確認できます。

```bash
bundle exec rails db:migrate:status:cable
bundle exec rails runner 'ActionCable.server.broadcast("verify", {t: Time.now.to_i}); sleep 1; puts ActionCable.server.pubsub.class; puts SolidCable::Message.count'
```

## prod について

prod の Redis は **ElastiCache**（レプリケーショングループ `dreamkast-prod-redis`、`cache.t4g.micro` × 3、Redis 6.0.5）で、ECS サービスではないため同じ方法は使えません。ElastiCache に stop/start はないので、prod リリース後に `CurrConnections` が 0 に張り付くのを確認してから、最終スナップショットを取得して削除する流れになります。

参考として、現時点（prod リリース前）の `CurrConnections` は平均 5.2 / 最大 6.0 で推移しています。これがベースラインです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiZdLcEGBjBSTkbhYPSW4N
