### PR TITLE
feat(otelcol): transform stg logs for Mackerel search

### DIFF
--- a/ecspresso/stg/dreamkast/files/otelcol-config.yaml
+++ b/ecspresso/stg/dreamkast/files/otelcol-config.yaml
@@ -35,6 +35,9 @@ processors:
   resource/dreamkast:
     attributes:
       - action: upsert
+        key: service.namespace
+        value: dreamkast
+      - action: upsert
         key: service.name
         value: dreamkast
       - action: upsert

--- a/ecspresso/stg/dreamkast/files/otelcol-config.yaml
+++ b/ecspresso/stg/dreamkast/files/otelcol-config.yaml
@@ -35,14 +35,45 @@ processors:
   resource/dreamkast:
     attributes:
       - action: upsert
-        key: service.namespace
-        value: dreamkast
-      - action: upsert
         key: service.name
         value: dreamkast
       - action: upsert
         key: deployment.environment.name
         value: stg
+  transform/mackerel_logs:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        statements:
+          # JSON文字列を構造化ログに変換
+          - set(body, ParseJSON(body))
+            where IsString(body)
+
+          # log level -> OpenTelemetry Severity
+          - set(severity_text, body["level"])
+            where IsMap(body) and body["level"] != nil
+
+          - set(severity_number, SEVERITY_NUMBER_DEBUG)
+            where IsMap(body) and body["level"] == "DEBUG"
+
+          - set(severity_number, SEVERITY_NUMBER_INFO)
+            where IsMap(body) and body["level"] == "INFO"
+
+          - set(severity_number, SEVERITY_NUMBER_WARN)
+            where IsMap(body) and (body["level"] == "WARN" or body["level"] == "WARNING")
+
+          - set(severity_number, SEVERITY_NUMBER_ERROR)
+            where IsMap(body) and body["level"] == "ERROR"
+
+          - set(severity_number, SEVERITY_NUMBER_FATAL)
+            where IsMap(body) and body["level"] == "FATAL"
+
+          # Mackerelの構造化ログ検索用
+          - set(body["deployment.environment.name"], resource.attributes["deployment.environment.name"])
+            where IsMap(body) and resource.attributes["deployment.environment.name"] != nil
+
+          - set(body["service.name"], resource.attributes["service.name"])
+            where IsMap(body) and resource.attributes["service.name"] != nil
 
   resourcedetection:
     detectors: [env, ecs]
@@ -91,6 +122,11 @@ service:
       exporters: [mackerelotlp]
     logs:
       receivers: [otlp]
-      processors: [resource/dreamkast, resourcedetection, batch/logs]
+      processors:
+        - attributes
+        - resource/dreamkast
+        - resourcedetection
+        - transform/mackerel_logs
+        - batch/logs
       exporters: [mackerelotlp,otlphttp/loki]
   extensions: [health_check]


### PR DESCRIPTION
MackerelでFluentdから受けたったログのログレベルや`deployment.environment.name`を設定

https://mackerel.io/ja/blog/entry/tech/sending-logs-from-rails#%E6%96%B9%E6%B3%952Fluentd%E7%B5%8C%E7%94%B1%E3%81%A7%E8%BB%A2%E9%80%81%E3%81%99%E3%82%8B

すでに適用済なので、下記リンクから状態を確認できます。

https://mackerel.io/orgs/cloudnativedays-o11y/logs/search?service=dreamkast&timezone=Local&severities=INFO#period=30m
